### PR TITLE
feat: add 60s cache for cockpit freight metrics

### DIFF
--- a/drizzle/0001_freight_simulation_logs.sql
+++ b/drizzle/0001_freight_simulation_logs.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `freight_simulation_logs` (
+	`id` char(36) NOT NULL,
+	`tenant_id` varchar(100) NOT NULL,
+	`uf` varchar(2) NOT NULL,
+	`peso` decimal(10,2) NOT NULL,
+	`valor` decimal(10,2) NOT NULL,
+	`prazo` int NOT NULL,
+	`cep_hash` varchar(64) NOT NULL,
+	`created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT `freight_simulation_logs_id` PRIMARY KEY(`id`)
+);
+
+CREATE INDEX `idx_freight_logs_tenant_created_at`
+ON `freight_simulation_logs` (`tenant_id`,`created_at`);
+
+CREATE INDEX `idx_freight_logs_tenant_uf_created_at`
+ON `freight_simulation_logs` (`tenant_id`,`uf`,`created_at`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771524432920,
       "tag": "0000_rich_sleepwalker",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1771533550106,
+      "tag": "0001_freight_simulation_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cockpit/metrics/freight/__tests__/route.test.ts
+++ b/src/app/api/cockpit/metrics/freight/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { getDb } from '../../../../../../infra/db';
+import { getSessionUser } from '../../../../../../infra/auth/session';
+
+const mockExecute = vi.fn();
+
+vi.mock('../../../../../../infra/db', () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock('../../../../../../infra/auth/session', () => ({
+  getSessionUser: vi.fn(),
+}));
+
+vi.mock('../../../../../../infra/redis.client', () => ({
+  redisClient: {
+    isAvailable: vi.fn().mockReturnValue(false),
+    get: vi.fn(),
+    set: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock('../../../../../../infra/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe('GET /api/cockpit/metrics/freight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDb).mockResolvedValue({ execute: mockExecute } as never);
+    vi.mocked(getSessionUser).mockResolvedValue({
+      sub: 'user-1',
+      email: 'user@example.com',
+      tenantId: 'tenant-from-session',
+      role: 'manager',
+    });
+  });
+
+  it('returns metrics using tenantId from auth context and ignores arbitrary headers', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ total: '3' }], []])
+      .mockResolvedValueOnce([[{ uf: 'SP', count: '2' }, { uf: 'RJ', count: '1' }], []])
+      .mockResolvedValueOnce([[{ uf: 'RJ', avg_valor: '19.50' }, { uf: 'SP', avg_valor: '25.00' }], []])
+      .mockResolvedValueOnce([[{ avg_peso: '2.15' }], []])
+      .mockResolvedValueOnce([[{ uf: 'RJ', avg_prazo: '3.00' }, { uf: 'SP', avg_prazo: '2.00' }], []])
+      .mockResolvedValueOnce([[{ date: '2026-02-01', count: '1' }, { date: '2026-02-02', count: '2' }], []]);
+
+    const headerGet = vi.fn().mockReturnValue('spoofed-tenant');
+    const request = {
+      headers: { get: headerGet },
+      cookies: { get: vi.fn() },
+    } as never;
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      total_simulations_7d: 3,
+      top_ufs_7d: [
+        { uf: 'SP', count: 2 },
+        { uf: 'RJ', count: 1 },
+      ],
+      avg_valor_by_uf_7d: [
+        { uf: 'RJ', avg_valor: 19.5 },
+        { uf: 'SP', avg_valor: 25 },
+      ],
+      avg_peso_7d: 2.15,
+      avg_prazo_by_uf_7d: [
+        { uf: 'RJ', avg_prazo: 3 },
+        { uf: 'SP', avg_prazo: 2 },
+      ],
+      daily_14d: [
+        { date: '2026-02-01', count: 1 },
+        { date: '2026-02-02', count: 2 },
+      ],
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(6);
+
+    expect(headerGet).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when auth context has no tenantId', async () => {
+    vi.mocked(getSessionUser).mockResolvedValue(null);
+
+    const request = {
+      headers: new Headers({ 'x-tenant-id': 'spoofed-tenant' }),
+    } as never;
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: 'Unauthorized' });
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cockpit/metrics/freight/route.ts
+++ b/src/app/api/cockpit/metrics/freight/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sql } from 'drizzle-orm';
+import { getDb } from '../../../../../infra/db';
+import { getSessionUser } from '../../../../../infra/auth/session';
+import { logger } from '../../../../../infra/logger';
+import { redisClient } from '../../../../../infra/redis.client';
+
+interface FreightMetricsResponse {
+  total_simulations_7d: number;
+  top_ufs_7d: Array<{ uf: string; count: number }>;
+  avg_valor_by_uf_7d: Array<{ uf: string; avg_valor: number }>;
+  avg_peso_7d: number;
+  avg_prazo_by_uf_7d: Array<{ uf: string; avg_prazo: number }>;
+  daily_14d: Array<{ date: string; count: number }>;
+}
+
+interface FreightCacheEntry {
+  expiresAt: number;
+  payload: FreightMetricsResponse;
+}
+
+const CACHE_TTL_SECONDS = 60;
+const CACHE_TTL_MS = CACHE_TTL_SECONDS * 1000;
+
+const globalForFreightMetricsCache = globalThis as typeof globalThis & {
+  cockpitFreightMetricsCache?: Map<string, FreightCacheEntry>;
+};
+
+const inMemoryCache =
+  globalForFreightMetricsCache.cockpitFreightMetricsCache ??
+  (globalForFreightMetricsCache.cockpitFreightMetricsCache = new Map<string, FreightCacheEntry>());
+
+function unwrapRows<T>(result: unknown): T[] {
+  if (Array.isArray(result) && Array.isArray(result[0])) {
+    return result[0] as T[];
+  }
+  if (Array.isArray(result)) {
+    return result as T[];
+  }
+  return [];
+}
+
+async function readFromCache(cacheKey: string, tenantId: string): Promise<FreightMetricsResponse | null> {
+  try {
+    if (redisClient.isAvailable()) {
+      const cached = await redisClient.get<FreightMetricsResponse>(cacheKey);
+      if (cached) {
+        logger.info('cockpit/metrics/freight: cache_hit', { tenantId, cache: 'redis' });
+        return cached;
+      }
+      logger.info('cockpit/metrics/freight: cache_miss', { tenantId, cache: 'redis' });
+      return null;
+    }
+  } catch (error) {
+    logger.warn('cockpit/metrics/freight: cache read failed', { tenantId, cache: 'redis' }, error as Error);
+  }
+
+  try {
+    const cachedEntry = inMemoryCache.get(cacheKey);
+
+    if (cachedEntry && cachedEntry.expiresAt > Date.now()) {
+      logger.info('cockpit/metrics/freight: cache_hit', { tenantId, cache: 'memory' });
+      return cachedEntry.payload;
+    }
+
+    if (cachedEntry) {
+      inMemoryCache.delete(cacheKey);
+    }
+
+    logger.info('cockpit/metrics/freight: cache_miss', { tenantId, cache: 'memory' });
+  } catch (error) {
+    logger.warn('cockpit/metrics/freight: cache read failed', { tenantId, cache: 'memory' }, error as Error);
+  }
+
+  return null;
+}
+
+function writeToCache(cacheKey: string, tenantId: string, payload: FreightMetricsResponse): void {
+  if (redisClient.isAvailable()) {
+    redisClient.set<FreightMetricsResponse>(cacheKey, payload, CACHE_TTL_SECONDS).catch((error: unknown) => {
+      logger.warn('cockpit/metrics/freight: cache write failed', { tenantId, cache: 'redis' }, error as Error);
+    });
+    return;
+  }
+
+  try {
+    inMemoryCache.set(cacheKey, {
+      payload,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+  } catch (error) {
+    logger.warn('cockpit/metrics/freight: cache write failed', { tenantId, cache: 'memory' }, error as Error);
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const startedAt = Date.now();
+  let tenantId = 'unknown';
+
+  try {
+    const sessionUser = await getSessionUser(request);
+
+    if (!sessionUser?.tenantId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    tenantId = sessionUser.tenantId;
+    const cacheKey = `cockpit:metrics:freight:${tenantId}`;
+
+    const cachedPayload = await readFromCache(cacheKey, tenantId);
+    if (cachedPayload) {
+      return NextResponse.json(cachedPayload, {
+        status: 200,
+        headers: { 'Cache-Control': 'private, max-age=60' },
+      });
+    }
+
+    const db = await getDb();
+
+    const [totalResult, topUfsResult, avgValorByUfResult, avgPesoResult, avgPrazoByUfResult, dailyResult] =
+      await Promise.all([
+        db.execute(sql`
+          SELECT COUNT(*) AS total
+          FROM freight_simulation_logs
+          WHERE tenant_id = ${tenantId}
+            AND created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)
+        `),
+        db.execute(sql`
+          SELECT uf, COUNT(*) AS count
+          FROM freight_simulation_logs
+          WHERE tenant_id = ${tenantId}
+            AND created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)
+          GROUP BY uf
+          ORDER BY count DESC, uf ASC
+        `),
+        db.execute(sql`
+          SELECT uf, AVG(valor) AS avg_valor
+          FROM freight_simulation_logs
+          WHERE tenant_id = ${tenantId}
+            AND created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)
+          GROUP BY uf
+          ORDER BY uf ASC
+        `),
+        db.execute(sql`
+          SELECT AVG(peso) AS avg_peso
+          FROM freight_simulation_logs
+          WHERE tenant_id = ${tenantId}
+            AND created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)
+        `),
+        db.execute(sql`
+          SELECT uf, AVG(prazo) AS avg_prazo
+          FROM freight_simulation_logs
+          WHERE tenant_id = ${tenantId}
+            AND created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)
+          GROUP BY uf
+          ORDER BY uf ASC
+        `),
+        db.execute(sql`
+          SELECT DATE(created_at) AS date, COUNT(*) AS count
+          FROM freight_simulation_logs
+          WHERE tenant_id = ${tenantId}
+            AND created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 14 DAY)
+          GROUP BY DATE(created_at)
+          ORDER BY date ASC
+        `),
+      ]);
+
+    const totalRows = unwrapRows<{ total: number | string }>(totalResult);
+    const topUfsRows = unwrapRows<{ uf: string; count: number | string }>(topUfsResult);
+    const avgValorRows = unwrapRows<{ uf: string; avg_valor: number | string | null }>(avgValorByUfResult);
+    const avgPesoRows = unwrapRows<{ avg_peso: number | string | null }>(avgPesoResult);
+    const avgPrazoRows = unwrapRows<{ uf: string; avg_prazo: number | string | null }>(avgPrazoByUfResult);
+    const dailyRows = unwrapRows<{ date: string | Date; count: number | string }>(dailyResult);
+
+    const payload: FreightMetricsResponse = {
+      total_simulations_7d: Number(totalRows[0]?.total ?? 0),
+      top_ufs_7d: topUfsRows.map((row) => ({ uf: row.uf, count: Number(row.count) })),
+      avg_valor_by_uf_7d: avgValorRows.map((row) => ({ uf: row.uf, avg_valor: Number(row.avg_valor ?? 0) })),
+      avg_peso_7d: Number(avgPesoRows[0]?.avg_peso ?? 0),
+      avg_prazo_by_uf_7d: avgPrazoRows.map((row) => ({ uf: row.uf, avg_prazo: Number(row.avg_prazo ?? 0) })),
+      daily_14d: dailyRows.map((row) => ({
+        date: typeof row.date === 'string' ? row.date : row.date.toISOString().slice(0, 10),
+        count: Number(row.count),
+      })),
+    };
+
+    writeToCache(cacheKey, tenantId, payload);
+
+    return NextResponse.json(payload, {
+      status: 200,
+      headers: { 'Cache-Control': 'private, max-age=60' },
+    });
+  } catch (error) {
+    logger.error('cockpit/metrics/freight: unexpected error', error as Error, { tenantId });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  } finally {
+    const durationMs = Date.now() - startedAt;
+    const logContext = { tenantId, duration_ms: durationMs };
+
+    if (durationMs > 500) {
+      logger.warn('cockpit/metrics/freight: slow request', logContext);
+    } else {
+      logger.info('cockpit/metrics/freight: request completed', logContext);
+    }
+  }
+}

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -48,6 +48,7 @@ export async function POST(request: NextRequest) {
     const result = await freightService.calculateFreight({
       destinationCep,
       quantity,
+      tenantId,
       unitWeight,
       dimensions,
     });
@@ -55,6 +56,7 @@ export async function POST(request: NextRequest) {
     // 4. Persist simulation with tenant context in route handler
     if (result.success && result.options.length > 0) {
       const bestOption = result.options[0];
+
       try {
         await simulationRepository.saveSimulation({
           id: randomUUID(),

--- a/src/app/cockpit/_components/freight-metrics-dashboard.tsx
+++ b/src/app/cockpit/_components/freight-metrics-dashboard.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+interface FreightMetricsData {
+  total_simulations_7d: number;
+  top_ufs_7d: Array<{ uf: string; count: number }>;
+  avg_valor_by_uf_7d: Array<{ uf: string; avg_valor: number }>;
+  avg_peso_7d: number;
+  avg_prazo_by_uf_7d: Array<{ uf: string; avg_prazo: number }>;
+  daily_14d: Array<{ date: string; count: number }>;
+}
+
+const POLL_INTERVAL_MS = 60_000;
+
+const EMPTY_DATA: FreightMetricsData = {
+  total_simulations_7d: 0,
+  top_ufs_7d: [],
+  avg_valor_by_uf_7d: [],
+  avg_peso_7d: 0,
+  avg_prazo_by_uf_7d: [],
+  daily_14d: [],
+};
+
+function ListSection({
+  title,
+  rows,
+  valueFormatter,
+}: {
+  title: string;
+  rows: Array<{ uf: string; value: number }>;
+  valueFormatter?: (value: number) => string;
+}) {
+  return (
+    <section className="rounded-2xl border border-[hsl(var(--cockpit-border))] bg-[hsl(var(--cockpit-surface))] overflow-hidden">
+      <div className="px-5 py-3 border-b border-[hsl(var(--cockpit-border))] bg-[hsl(var(--cockpit-bg))]/30">
+        <h3 className="text-sm font-semibold text-[hsl(var(--cockpit-text))]">{title}</h3>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-5 py-4 text-sm text-[hsl(var(--cockpit-text-muted))]">Sem dados no período.</p>
+      ) : (
+        <ul className="divide-y divide-[hsl(var(--cockpit-border))]">
+          {rows.map((row) => (
+            <li key={`${title}-${row.uf}`} className="px-5 py-3 flex items-center justify-between text-sm">
+              <span className="font-medium text-[hsl(var(--cockpit-text))]">{row.uf}</span>
+              <span className="text-[hsl(var(--cockpit-text-muted))]">
+                {valueFormatter ? valueFormatter(row.value) : row.value}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export function FreightMetricsDashboard() {
+  const [data, setData] = useState<FreightMetricsData>(EMPTY_DATA);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchMetrics = async (showLoader = false) => {
+      if (showLoader) {
+        setLoading(true);
+      }
+
+      try {
+        const response = await fetch('/api/cockpit/metrics/freight', {
+          method: 'GET',
+          credentials: 'same-origin',
+          cache: 'no-store',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed with status ${response.status}`);
+        }
+
+        const payload = (await response.json()) as FreightMetricsData;
+
+        if (!isMounted) {
+          return;
+        }
+
+        setData(payload);
+        setError(null);
+      } catch {
+        if (!isMounted) {
+          return;
+        }
+        setError('Não foi possível carregar as métricas de frete.');
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchMetrics(true);
+    const timer = setInterval(() => {
+      void fetchMetrics(false);
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      isMounted = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const dailyMax = useMemo(
+    () => Math.max(1, ...data.daily_14d.map((point) => point.count)),
+    [data.daily_14d]
+  );
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-[hsl(var(--cockpit-border))] bg-[hsl(var(--cockpit-surface))] overflow-hidden">
+        <div className="px-5 py-3 border-b border-[hsl(var(--cockpit-border))] bg-[hsl(var(--cockpit-bg))]/30">
+          <h2 className="text-base font-semibold text-[hsl(var(--cockpit-text))]">Métricas de Frete</h2>
+          <p className="text-xs text-[hsl(var(--cockpit-text-muted))]">Últimos 7 dias (KPIs) e série diária de 14 dias</p>
+        </div>
+
+        {error ? <p className="px-5 py-4 text-sm text-red-500">{error}</p> : null}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-5">
+          <div className="rounded-xl border border-[hsl(var(--cockpit-border))] p-4">
+            <p className="text-xs uppercase tracking-wide text-[hsl(var(--cockpit-text-muted))]">Total simulações 7d</p>
+            <p className="mt-2 text-3xl font-semibold text-[hsl(var(--cockpit-text))]">
+              {loading ? '...' : data.total_simulations_7d}
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-[hsl(var(--cockpit-border))] p-4">
+            <p className="text-xs uppercase tracking-wide text-[hsl(var(--cockpit-text-muted))]">Média peso 7d</p>
+            <p className="mt-2 text-3xl font-semibold text-[hsl(var(--cockpit-text))]">
+              {loading ? '...' : `${data.avg_peso_7d.toFixed(2)} kg`}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <ListSection
+          title="Top UFs 7d"
+          rows={data.top_ufs_7d.map((item) => ({ uf: item.uf, value: item.count }))}
+        />
+
+        <ListSection
+          title="Média valor por UF 7d"
+          rows={data.avg_valor_by_uf_7d.map((item) => ({ uf: item.uf, value: item.avg_valor }))}
+          valueFormatter={(value) => `R$ ${value.toFixed(2)}`}
+        />
+
+        <ListSection
+          title="Média prazo por UF 7d"
+          rows={data.avg_prazo_by_uf_7d.map((item) => ({ uf: item.uf, value: item.avg_prazo }))}
+          valueFormatter={(value) => `${value.toFixed(1)} dias`}
+        />
+      </div>
+
+      <section className="rounded-2xl border border-[hsl(var(--cockpit-border))] bg-[hsl(var(--cockpit-surface))] overflow-hidden">
+        <div className="px-5 py-3 border-b border-[hsl(var(--cockpit-border))] bg-[hsl(var(--cockpit-bg))]/30">
+          <h3 className="text-sm font-semibold text-[hsl(var(--cockpit-text))]">Série diária 14d</h3>
+        </div>
+
+        {data.daily_14d.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-[hsl(var(--cockpit-text-muted))]">Sem dados no período.</p>
+        ) : (
+          <ul className="divide-y divide-[hsl(var(--cockpit-border))]">
+            {data.daily_14d.map((point) => (
+              <li key={point.date} className="px-5 py-3 flex items-center gap-3">
+                <span className="text-sm w-28 text-[hsl(var(--cockpit-text))]">{point.date}</span>
+                <div className="h-2 flex-1 rounded-full bg-[hsl(var(--cockpit-bg))] overflow-hidden">
+                  <div
+                    className="h-full bg-[hsl(var(--cockpit-accent))]"
+                    style={{ width: `${(point.count / dailyMax) * 100}%` }}
+                  />
+                </div>
+                <span className="text-sm font-medium text-[hsl(var(--cockpit-text-muted))] min-w-8 text-right">{point.count}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/cockpit/page.tsx
+++ b/src/app/cockpit/page.tsx
@@ -1,4 +1,5 @@
 import { CockpitMetrics } from './_components/cockpit-metrics';
+import { FreightMetricsDashboard } from './_components/freight-metrics-dashboard';
 
 export default function CockpitPage() {
     return (
@@ -15,6 +16,8 @@ export default function CockpitPage() {
 
             {/* Metrics Grid */}
             <CockpitMetrics />
+
+            <FreightMetricsDashboard />
 
             {/* Recent Activity Mock (To be refactored later) */}
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -65,3 +65,19 @@ export const users = mysqlTable('users', {
 
 export type UserRecord = typeof users.$inferSelect;
 export type NewUserRecord = typeof users.$inferInsert;
+
+// --- Freight Simulation Logs (metrics/audit) ---
+
+export const freightSimulationLogs = mysqlTable('freight_simulation_logs', {
+    id: varchar('id', { length: 36 }).primaryKey().notNull(),
+    tenantId: varchar('tenant_id', { length: 100 }).notNull(),
+    uf: varchar('uf', { length: 2 }).notNull(),
+    peso: decimal('peso', { precision: 10, scale: 2 }).notNull(),
+    valor: decimal('valor', { precision: 10, scale: 2 }).notNull(),
+    prazo: int('prazo').notNull(),
+    cepHash: varchar('cep_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`).notNull(),
+});
+
+export type FreightSimulationLogRecord = typeof freightSimulationLogs.$inferSelect;
+export type NewFreightSimulationLogRecord = typeof freightSimulationLogs.$inferInsert;

--- a/src/infra/repositories/__tests__/freight-simulation-log.repository.test.ts
+++ b/src/infra/repositories/__tests__/freight-simulation-log.repository.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FreightSimulationLogRepository } from '../freight-simulation-log.repository';
+
+const mockDb = vi.hoisted(() => ({
+  insert: vi.fn().mockReturnThis(),
+  values: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../db', () => ({
+  getDb: vi.fn().mockResolvedValue(mockDb),
+}));
+
+vi.mock('../../logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+describe('FreightSimulationLogRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists hashed CEP and normalized values', async () => {
+    const repository = new FreightSimulationLogRepository();
+
+    await repository.saveMetric({
+      tenantId: 'tenant-1',
+      destinationCep: '01310930',
+      totalWeight: 2.5,
+      bestPrice: 18.9,
+      bestDeliveryTime: 4,
+      uf: 'sp',
+    });
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      uf: 'SP',
+      peso: '2.50',
+      valor: '18.90',
+      prazo: 4,
+      cepHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    }));
+  });
+});

--- a/src/infra/repositories/freight-simulation-log.repository.ts
+++ b/src/infra/repositories/freight-simulation-log.repository.ts
@@ -1,0 +1,45 @@
+import { createHash, randomUUID } from 'crypto';
+import { getDb } from '../db';
+import { freightSimulationLogs } from '../../drizzle/schema';
+import { logger } from '../logger';
+
+interface SaveFreightSimulationMetricInput {
+  tenantId: string;
+  destinationCep: string;
+  totalWeight: number;
+  bestPrice: number;
+  bestDeliveryTime: number;
+  uf?: string;
+}
+
+export class FreightSimulationLogRepository {
+  async saveMetric(input: SaveFreightSimulationMetricInput): Promise<void> {
+    const db = await getDb();
+
+    const uf = (input.uf || 'NA').toUpperCase().slice(0, 2);
+
+    await db.insert(freightSimulationLogs).values({
+      id: randomUUID(),
+      tenantId: input.tenantId,
+      uf,
+      peso: input.totalWeight.toFixed(2),
+      valor: input.bestPrice.toFixed(2),
+      prazo: input.bestDeliveryTime,
+      cepHash: this.hashCep(input.destinationCep),
+    });
+  }
+
+  private hashCep(cep: string): string {
+    return createHash('sha256').update(cep).digest('hex');
+  }
+
+  saveMetricInBackground(input: SaveFreightSimulationMetricInput): void {
+    void this.saveMetric(input).catch((error) => {
+      logger.error('Failed to persist freight simulation metric', error as Error, {
+        tenantId: input.tenantId,
+      });
+    });
+  }
+}
+
+export const freightSimulationLogRepository = new FreightSimulationLogRepository();

--- a/src/legacy/freight.controller.ts
+++ b/src/legacy/freight.controller.ts
@@ -204,6 +204,7 @@ class FreightController {
       const freightRequest: FreightRequest = {
         destinationCep: session.cep,
         quantity,
+        tenantId,
       };
 
       // 1. Metrics Hook: REQUESTED

--- a/src/modules/freight/freight.service.ts
+++ b/src/modules/freight/freight.service.ts
@@ -17,6 +17,7 @@ import type {
 } from './freight.types';
 import { redisClient } from '../../infra/redis.client';
 import { freightTableProvider } from '../../infra/freight-table';
+import { freightSimulationLogRepository } from '../../infra/repositories/freight-simulation-log.repository';
 
 
 
@@ -60,17 +61,20 @@ class FreightService {
       const sortedOptions = this.sortAndLimitOptions(options);
       const bestOption = sortedOptions[0];
 
-      // Calculate margin (placeholder logic for now, as requested to be added in previous turns but we are focusing on persistence here)
-      // Assuming naive margin calculation if not present.
-      const bestMargin = bestOption.price * 0.2; // Example: 20% margin
-
       logger.info('Freight calculation completed', {
         optionsCount: sortedOptions.length,
         totalWeight,
       });
 
-      // Persistence is handled by callers (route handlers) with proper tenant context.
-      // FreightService remains calc-focused.
+      if (request.tenantId && bestOption) {
+        void freightSimulationLogRepository.saveMetricInBackground({
+          tenantId: request.tenantId,
+          destinationCep: request.destinationCep,
+          totalWeight,
+          bestPrice: bestOption.price,
+          bestDeliveryTime: bestOption.deliveryTime,
+        });
+      }
 
       // Cache the result
       await this.cacheResult(request, totalWeight, options);

--- a/src/modules/freight/freight.types.ts
+++ b/src/modules/freight/freight.types.ts
@@ -9,6 +9,7 @@
 export interface FreightRequest {
   destinationCep: string;
   quantity: number;
+  tenantId?: string;
   unitWeight?: number; // kg (optional, uses default if not provided)
   dimensions?: {
     width: number; // cm


### PR DESCRIPTION
### Motivation
- Reduce repeated DB work and improve response latency for `GET /api/cockpit/metrics/freight` by caching results per `tenantId` for 60 seconds. 
- Use Redis when available for shared caching and provide an in-memory `globalThis` fallback so the endpoint remains functional in all environments. 
- Ensure caching is non-blocking and resilient so cache errors never break the endpoint or change its payload.

### Description
- Added tenant-scoped caching to the freight metrics route with key format `cockpit:metrics:freight:{tenantId}`, TTL 60s, and response header `Cache-Control: private, max-age=60` (`src/app/api/cockpit/metrics/freight/route.ts`).
- Cache strategy: try `redisClient` first, and on Redis unavailability fall back to an in-memory `Map` stored on `globalThis` with per-entry expiration; both read and write paths log `cache_hit`/`cache_miss` and tolerate errors (logs only) so endpoint flow is uninterrupted. (`src/infra/redis.client.ts`, `src/app/api/cockpit/metrics/freight/route.ts`).
- Updated unit tests to mock the `redisClient` and keep caching behavior deterministic (`src/app/api/cockpit/metrics/freight/__tests__/route.test.ts`).
- Related additions and hardening: DB migration and schema for `freight_simulation_logs`, a new `FreightSimulationLogRepository` and its tests, small changes to persist freight simulation metrics from the service and route handlers, and a client-side `FreightMetricsDashboard` component (these changes support metrics collection used by the freight metrics queries). (`drizzle/0001_freight_simulation_logs.sql`, `src/drizzle/schema.ts`, `src/infra/repositories/freight-simulation-log.repository.ts`, `src/modules/freight/freight.service.ts`, `src/app/cockpit/_components/freight-metrics-dashboard.tsx`, and tests). 

### Testing
- Ran the full test suite with `npm test`, all tests passed: `Test Files 8 passed, Tests 52 passed`.
- Ran type checking with `npm run typecheck` (`tsc -p tsconfig.build.json --noEmit`), which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997745ceac88331b2125164adb12624)