### PR TITLE
fix(migrate): inline SQL migrations for Vercel serverless

### DIFF
--- a/src/app/api/db/migrate/route.ts
+++ b/src/app/api/db/migrate/route.ts
@@ -1,13 +1,75 @@
 import { NextResponse, NextRequest } from "next/server";
-import { drizzle } from "drizzle-orm/mysql2";
-import { migrate } from "drizzle-orm/mysql2/migrator";
 import mysql from "mysql2/promise";
-import path from "path";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function POST(request: NextRequest) {
+// All migrations as inline SQL — avoids filesystem dependency in Vercel serverless
+const MIGRATIONS = [
+    {
+        name: "0000_simulations_hardening",
+        sql: [
+            "ALTER TABLE `simulations` ADD COLUMN IF NOT EXISTS `idempotency_key` varchar(255)",
+            "ALTER TABLE `simulations` ADD COLUMN IF NOT EXISTS `event` varchar(50) NOT NULL DEFAULT 'FREIGHT_QUOTED'",
+            "CREATE UNIQUE INDEX IF NOT EXISTS `simulations_idempotency_key_unique` ON `simulations` (`idempotency_key`)",
+        ],
+    },
+    {
+        name: "create_users_table",
+        sql: [
+            `CREATE TABLE IF NOT EXISTS \`users\` (
+        \`id\` varchar(36) NOT NULL,
+        \`email\` varchar(255) NOT NULL,
+        \`password_hash\` varchar(512) NOT NULL,
+        \`tenant_id\` varchar(36) NOT NULL,
+        \`role\` varchar(20) NOT NULL DEFAULT 'operator',
+        \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (\`id\`),
+        UNIQUE KEY \`idx_user_email\` (\`email\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        ],
+    },
+    {
+        name: "create_project_reports_table",
+        sql: [
+            `CREATE TABLE IF NOT EXISTS \`project_reports\` (
+        \`id\` varchar(36) NOT NULL,
+        \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        \`module_key\` varchar(100) NOT NULL,
+        \`title\` varchar(255) NOT NULL,
+        \`summary\` text NOT NULL,
+        \`status\` varchar(20) NOT NULL DEFAULT 'done',
+        \`changes\` text,
+        \`metrics\` text,
+        \`risks\` text,
+        \`next_actions\` text,
+        \`tags\` text,
+        \`source\` varchar(20) NOT NULL DEFAULT 'manual',
+        \`content_hash\` varchar(64) NOT NULL,
+        PRIMARY KEY (\`id\`),
+        UNIQUE KEY \`idx_report_hash\` (\`content_hash\`),
+        KEY \`idx_report_module\` (\`module_key\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        ],
+    },
+    {
+        name: "create_freight_funnel_events",
+        sql: [
+            `CREATE TABLE IF NOT EXISTS \`freight_funnel_events\` (
+        \`id\` varchar(36) NOT NULL,
+        \`session_id\` varchar(255) NOT NULL,
+        \`tenant_id\` varchar(36) NOT NULL,
+        \`stage\` varchar(50) NOT NULL,
+        \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (\`id\`),
+        KEY \`idx_funnel_session\` (\`session_id\`),
+        KEY \`idx_funnel_tenant\` (\`tenant_id\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        ],
+    },
+];
+
+async function handler(request: NextRequest) {
     try {
         const url = new URL(request.url);
         const token = request.headers.get('x-seed-token') || url.searchParams.get('token');
@@ -18,38 +80,50 @@ export async function POST(request: NextRequest) {
 
         const dbUrl = process.env.DATABASE_URL;
         if (!dbUrl) {
-            return NextResponse.json({ success: false, error: 'DATABASE_URL is missing' }, { status: 500 });
-        }
-        if (!dbUrl.includes('/lojacond')) {
-            return NextResponse.json({ success: false, error: 'DATABASE_URL missing database name (/lojacond)' }, { status: 500 });
+            return NextResponse.json({ success: false, error: 'DATABASE_URL missing' }, { status: 500 });
         }
 
         const urlObj = new URL(dbUrl);
-        console.log(`Connecting to DB for migration: Host=${urlObj.hostname}, Database=${urlObj.pathname.replace('/', '')}`);
+        console.log(`[/api/db/migrate] DB: host=${urlObj.hostname}, db=${urlObj.pathname.replace('/', '')}`);
 
         const connection = await mysql.createConnection({
             uri: dbUrl,
-            multipleStatements: true,
             ssl: { rejectUnauthorized: true }
         });
 
-        const db = drizzle(connection);
+        const applied: string[] = [];
+        const errors: string[] = [];
 
-        console.log('Running Drizzle migrations...');
-        const migrationsFolder = path.join(process.cwd(), 'drizzle');
-
-        await migrate(db, { migrationsFolder });
+        for (const migration of MIGRATIONS) {
+            for (const stmt of migration.sql) {
+                try {
+                    await connection.execute(stmt);
+                    applied.push(migration.name);
+                } catch (e: any) {
+                    console.error(`[migrate] Failed ${migration.name}:`, e.message);
+                    errors.push(`${migration.name}: ${e.message}`);
+                }
+            }
+        }
 
         await connection.end();
 
-        return NextResponse.json({ success: true, message: 'Migrations applied successfully' });
+        return NextResponse.json({
+            success: errors.length === 0,
+            applied: [...new Set(applied)].length,
+            migrations: [...new Set(applied)],
+            errors: errors.length > 0 ? errors : undefined,
+        });
     } catch (err: any) {
         console.error("[/api/db/migrate] error", err);
         return NextResponse.json({ success: false, error: err?.message ?? String(err) }, { status: 500 });
     }
 }
 
+export async function POST(request: NextRequest) {
+    return handler(request);
+}
+
 export async function GET(request: NextRequest) {
-    // Allow GET as well for easy triggering via browser if needed
-    return POST(request);
+    return handler(request);
 }


### PR DESCRIPTION
Replace file-based Drizzle migrator with inline SQL (IF NOT EXISTS). The drizzle/ folder is gitignored so filesystem migrations never worked in Vercel.