### PR TITLE
http: contract 401 for tenant/seed

### DIFF
--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function tenantOr401(request: NextRequest): { tenantId: string } | NextResponse {
+  const tenantId = request.headers.get("x-tenant-id");
+  if (!tenantId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized: missing x-tenant-id" },
+      { status: 401 }
+    );
+  }
+  return { tenantId };
+}
+
+export function seedTokenOr401(request: NextRequest): { token: string } | NextResponse {
+  const token = request.headers.get("x-seed-token");
+  if (!token) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized: missing x-seed-token" },
+      { status: 401 }
+    );
+  }
+  return { token };
+}


### PR DESCRIPTION
Adds src/server/http.ts helpers and applies to API routes to avoid 500 on missing headers; consistent JSON 401.