### PR TITLE
fix: redis runtime-safe (vercel compatible)

### DIFF
--- a/src/infra/redis.client.ts
+++ b/src/infra/redis.client.ts
@@ -1,3 +1,15 @@
 import Redis from "ioredis";
 
-export const redis = new Redis(process.env.REDIS_URL as string);
+let redisInstance: Redis | null = null;
+
+export function getRedis() {
+  if (!process.env.REDIS_URL) {
+    return null;
+  }
+
+  if (!redisInstance) {
+    redisInstance = new Redis(process.env.REDIS_URL);
+  }
+
+  return redisInstance;
+}

--- a/src/server/rate-limit.ts
+++ b/src/server/rate-limit.ts
@@ -1,10 +1,15 @@
-import { redis } from "@/infra/redis.client";
+import { getRedis } from "@/infra/redis.client";
 import { NextResponse } from "next/server";
 
 const WINDOW_SECONDS = 60;
 const MAX_REQUESTS = 60;
 
 export async function rateLimitTenant(tenantId: string) {
+  const redis = getRedis();
+
+  // Preview/local sem REDIS_URL -> não bloquear
+  if (!redis) return null;
+
   const key = `rl:${tenantId}`;
   const current = await redis.incr(key);
 


### PR DESCRIPTION
Lazy Redis init. Rate limit disabled if REDIS_URL missing. Prevents Vercel build failure.