### PR TITLE
fix(sec): harden tenant isolation and close open admin endpoints

### DIFF
--- a/src/app/api/cockpit/metrics/funnel/route.ts
+++ b/src/app/api/cockpit/metrics/funnel/route.ts
@@ -22,30 +22,11 @@ const CACHE_TTL_SECONDS = 60;
 
 export async function GET(request: NextRequest) {
     try {
-        let tenantId: string;
-
-        // DEV bypass: allow testing metrics endpoints without session
-        if (
-            process.env.NODE_ENV === 'development' &&
-            process.env.COCKPIT_METRICS_DEV_BYPASS === '1'
-        ) {
-            // Get the first available tenant for DEV bypass testing
-            const db = await getDb();
-            // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const { tenants } = require('@/drizzle/schema');
-            const firstTenant = await db.select().from(tenants).limit(1);
-            if (!firstTenant || firstTenant.length === 0) {
-                return NextResponse.json({ error: 'No tenants found for dev bypass' }, { status: 400 });
-            }
-            tenantId = firstTenant[0].id;
-        } else {
-            // Production: authenticate via JWT cookie — no x-tenant-id header
-            const user = await getSessionUser(request);
-            if (!user?.tenantId) {
-                return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
-            }
-            tenantId = user.tenantId;
+        const user = await getSessionUser(request);
+        if (!user?.tenantId) {
+            return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
         }
+        const tenantId = user.tenantId;
 
         // 2. Try Redis Cache (with availability guard)
         const cacheKey = `cockpit:metrics:funnel:${tenantId}`;

--- a/src/app/api/painel-logistico/route.ts
+++ b/src/app/api/painel-logistico/route.ts
@@ -1,6 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
+import { isInternalTokenAuthorized } from '@/infra/config/internal-token';
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+    const token = request.headers.get('x-internal-token');
+    if (!isInternalTokenAuthorized(token)) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         const body = await request.json();
         return NextResponse.json({
@@ -9,7 +14,7 @@ export async function POST(request: Request) {
             message: 'Logistics Panel API is online',
             timestamp: new Date().toISOString(),
         });
-    } catch (error) {
+    } catch {
         return NextResponse.json({
             ok: false,
             error: 'Invalid JSON body',
@@ -18,10 +23,14 @@ export async function POST(request: Request) {
     }
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+    const token = request.headers.get('x-internal-token');
+    if (!isInternalTokenAuthorized(token)) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     return NextResponse.json({
         ok: true,
         message: 'Logistics Panel API (GET)',
         timestamp: new Date().toISOString()
-    })
+    });
 }

--- a/src/infra/auth/tenant-route-guard.ts
+++ b/src/infra/auth/tenant-route-guard.ts
@@ -44,5 +44,5 @@ export async function requireSessionTenantMatch(
     };
   }
 
-  return { ok: true, tenantId: normalizedTenantId, sessionUser };
+  return { ok: true, tenantId: sessionUser.tenantId, sessionUser };
 }


### PR DESCRIPTION
## O que muda

- **tenant-route-guard**: `tenantId` agora retornado de `sessionUser.tenantId` (não do parâmetro de URL) — todas as operações de DB derivam exclusivamente da sessão verificada
- **cockpit/metrics/funnel**: removido bloco `COCKPIT_METRICS_DEV_BYPASS` que pulava autenticação e expunha dados do primeiro tenant sem credenciais
- **/api/painel-logistico**: GET + POST protegidos com `x-internal-token` via `isInternalTokenAuthorized()` — retorna 401 sem token válido
- **db/migrate** e demais rotas cockpit: já corretas, nenhuma alteração

## Arquivos alterados (3)

| Arquivo | Mudança |
|---|---|
| `src/infra/auth/tenant-route-guard.ts` | `tenantId: sessionUser.tenantId` na linha de retorno |
| `src/app/api/cockpit/metrics/funnel/route.ts` | Remove bypass de dev (22 linhas) |
| `src/app/api/painel-logistico/route.ts` | Adiciona guard `x-internal-token` em GET + POST |

## Validação

- `npm run typecheck` → ✅ zero erros
- `npm run build` → ❌ `DATABASE_URL` ausente no ambiente local (erro pré-existente, não introduzido por este PR)
- Endpoints testados via `curl` no dev server local:
  - `GET /api/cockpit/metrics/funnel` sem sessão → `401 UNAUTHORIZED` ✅
  - `GET /api/painel-logistico` sem token → `401 Unauthorized` ✅
  - `POST /api/painel-logistico` sem token → `401 Unauthorized` ✅
  - `GET /api/painel-logistico` token errado → `401 Unauthorized` ✅

## O que NÃO foi alterado

- `main` — nenhum commit direto
- Schema do banco
- Arquitetura / RAG
- Demais rotas cockpit (`analytics/*`, `audit`, `metrics`, `metrics/freight`)
- `db/migrate` (GET já retorna 405, POST já protegido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)