### PR TITLE
refactor(infra): lazy DB pool initialization to allow builds without DATABASE_URL

### DIFF
--- a/src/infra/db.ts
+++ b/src/infra/db.ts
@@ -33,20 +33,19 @@ function validateAndLogDbUrl(): string {
     return dbUrl;
 }
 
-// Singleton initialization
-if (!globalForDb.conn) {
-    const dbUrl = validateAndLogDbUrl();
-    globalForDb.conn = mysql.createPool({
-        uri: dbUrl,
-        connectionLimit: 10,
-        multipleStatements: false,
-        timezone: 'Z',
-        ssl: { rejectUnauthorized: true },
-    });
-}
-
 export async function getDb() {
+    // Lazy initialization: only create pool when getDb() is first called
+    if (!globalForDb.conn) {
+        const dbUrl = validateAndLogDbUrl();
+        globalForDb.conn = mysql.createPool({
+            uri: dbUrl,
+            connectionLimit: 10,
+            multipleStatements: false,
+            timezone: 'Z',
+            ssl: { rejectUnauthorized: true },
+        });
+    }
     // Return drizzle instance using the singleton pool
-    return drizzle(globalForDb.conn!, { mode: 'default' });
+    return drizzle(globalForDb.conn, { mode: 'default' });
 }
 


### PR DESCRIPTION
## Objetivo

Permitir `npm run build` mesmo quando `DATABASE_URL` não está definida no ambiente.

Atualmente, o build falha com erro `DATABASE_URL is not set` porque a pool de conexão MySQL é inicializada **no momento da importação** do módulo `src/infra/db.ts`, não ao chamar a função.

## Solução

Mover a inicialização da pool de conexão para **inside de `getDb()`** (lazy initialization):

- Pool é criada apenas na primeira chamada de `getDb()` (runtime)
- Módulo pode ser importado durante build sem lançar erro
- Comportamento em runtime permanece **idêntico** quando `DATABASE_URL` existe

## Benefícios

| Cenário | Antes | Depois |
|---------|-------|--------|
| Build sem `DATABASE_URL` | ❌ ERRO: "DATABASE_URL is not set" | ✅ BUILD OK |
| Runtime com `DATABASE_URL` | ✅ Pool criada na importação | ✅ Pool criada on first call |
| Runtime sem `DATABASE_URL` | ✅ Erro na importação | ✅ Erro quando DB é acessado (apropriado) |

## Mudanças

**Arquivo:** `src/infra/db.ts`

1. Removeu linhas 36-46 (inicialização top-level)
2. Moveu para inside de `getDb()` com comentário de lazy init
3. Removeu `!` (non-null assertion) porque pool é garantida estar inicializada

```typescript
// Antes:
if (!globalForDb.conn) {
    const dbUrl = validateAndLogDbUrl();  // Lançado na importação
    globalForDb.conn = mysql.createPool(...);
}

// Depois:
export async function getDb() {
    if (!globalForDb.conn) {
        const dbUrl = validateAndLogDbUrl();  // Lançado apenas ao chamar getDb()
        globalForDb.conn = mysql.createPool(...);
    }
    return drizzle(globalForDb.conn, ...);
}
```

## Validação

✅ `npm run typecheck` — zero erros
✅ `npm run build` — **build succeeds WITHOUT DATABASE_URL** (antes: ❌ ERRO)
✅ Singleton pattern preservado (previne múltiplas pools em dev com HMR)
✅ Nenhuma mudança em comportamento quando `DATABASE_URL` está disponível

🤖 Generated with [Claude Code](https://claude.com/claude-code)