### PR TITLE
fix(infra): structured 503 errors for db-dependent routes

### DIFF
--- a/src/app/api/cockpit/metrics/funnel/route.ts
+++ b/src/app/api/cockpit/metrics/funnel/route.ts
@@ -6,6 +6,7 @@ import { freightFunnelEvents } from '@/drizzle/schema';
 import { sql, and, gte, eq } from 'drizzle-orm';
 import { redisClient } from "@/infra/redis.client";
 import { logger } from '@/infra/logger';
+import { makeRequestId, respondInfraError } from '@/infra/http/infra-error';
 
 export enum FunnelStage {
     FLOW_STARTED = 'FLOW_STARTED',
@@ -21,10 +22,11 @@ export enum FunnelStage {
 const CACHE_TTL_SECONDS = 60;
 
 export async function GET(request: NextRequest) {
+    const requestId = makeRequestId();
     try {
         const user = await getSessionUser(request);
         if (!user?.tenantId) {
-            return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+            return NextResponse.json({ error: 'UNAUTHORIZED', requestId }, { status: 401, headers: { 'X-Request-Id': requestId } });
         }
         const tenantId = user.tenantId;
 
@@ -38,6 +40,7 @@ export async function GET(request: NextRequest) {
                         headers: {
                             'Cache-Control': `private, max-age=${CACHE_TTL_SECONDS}`,
                             'X-Cache': 'HIT',
+                            'X-Request-Id': requestId,
                         },
                     });
                 }
@@ -139,11 +142,11 @@ export async function GET(request: NextRequest) {
             headers: {
                 'Cache-Control': `private, max-age=${CACHE_TTL_SECONDS}`,
                 'X-Cache': 'MISS',
+                'X-Request-Id': requestId,
             },
         });
 
     } catch (error) {
-        logger.error('Failed to fetch funnel metrics', error as Error);
-        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+        return respondInfraError(error, requestId);
     }
 }

--- a/src/app/api/cockpit/metrics/route.ts
+++ b/src/app/api/cockpit/metrics/route.ts
@@ -15,6 +15,8 @@ import { messageRepository } from '@/infra/repositories/message.repository';
 import { simulationRepository } from '@/infra/repositories/simulation.repository';
 import { redisClient } from "@/infra/redis.client";
 import { logger } from '@/infra/logger';
+import { getSessionUser } from '@/infra/auth/session';
+import { makeRequestId, respondInfraError } from '@/infra/http/infra-error';
 
 interface CockpitMetrics {
   mensagensHoje: number;
@@ -25,14 +27,13 @@ interface CockpitMetrics {
 
 const CACHE_TTL_SECONDS = 30;
 
-import { getSessionUser } from '@/infra/auth/session';
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  const requestId = makeRequestId();
   const user = await getSessionUser(request);
   const tenantId = user?.tenantId;
 
   if (!tenantId) {
-    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    return NextResponse.json({ error: 'UNAUTHORIZED', requestId }, { status: 401, headers: { 'X-Request-Id': requestId } });
   }
 
   const cacheKey = `cockpit:metrics:${tenantId}`;
@@ -45,7 +46,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         logger.debug('cockpit/metrics: cache hit', { tenantId });
         return NextResponse.json(cached, {
           status: 200,
-          headers: { 'Cache-Control': 'private, max-age=30' },
+          headers: { 'Cache-Control': 'private, max-age=30', 'X-Request-Id': requestId },
         });
       }
     }
@@ -78,10 +79,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(payload, {
       status: 200,
-      headers: { 'Cache-Control': 'private, max-age=30' },
+      headers: { 'Cache-Control': 'private, max-age=30', 'X-Request-Id': requestId },
     });
   } catch (error) {
-    logger.error('cockpit/metrics: unexpected error', error as Error, { tenantId });
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return respondInfraError(error, requestId);
   }
 }

--- a/src/app/api/internal/health/db/route.ts
+++ b/src/app/api/internal/health/db/route.ts
@@ -5,38 +5,36 @@
  * Executa SELECT 1 e mede latência.
  *
  * Resposta 200: { ok: true, latencyMs, timestamp }
- * Resposta 503: { ok: false, error, timestamp }
+ * Resposta 503: { ok: false, error, code, retryable, requestId }
  */
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { NextResponse, NextRequest } from "next/server";
 import { sql } from "drizzle-orm";
 import { getDb } from "@/infra/db";
+import { makeRequestId, respondInfraError } from "@/infra/http/infra-error";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const requestId = makeRequestId();
   const start = Date.now();
   try {
     const db = await getDb();
     await db.execute(sql`SELECT 1`);
     const latencyMs = Date.now() - start;
 
-    return NextResponse.json({
-      ok: true,
-      latencyMs,
-      timestamp: new Date().toISOString(),
-    });
-  } catch (err) {
-    const latencyMs = Date.now() - start;
-    const message = err instanceof Error ? err.message : String(err);
-
     return NextResponse.json(
       {
-        ok: false,
-        error: message,
+        ok: true,
         latencyMs,
         timestamp: new Date().toISOString(),
       },
-      { status: 503 }
+      {
+        headers: {
+          'X-Request-Id': requestId,
+        },
+      }
     );
+  } catch (err) {
+    return respondInfraError(err, requestId);
   }
 }

--- a/src/infra/db.ts
+++ b/src/infra/db.ts
@@ -2,6 +2,7 @@
 import { drizzle } from 'drizzle-orm/mysql2';
 import mysql from 'mysql2/promise';
 import { logger } from './logger';
+import { InfrastructureError, ErrorCode } from './errors';
 
 // Prevent multiple pools in development due to HMR
 const globalForDb = globalThis as unknown as {
@@ -11,7 +12,8 @@ const globalForDb = globalThis as unknown as {
 function validateAndLogDbUrl(): string {
     const dbUrl = process.env.DATABASE_URL;
     if (!dbUrl) {
-        throw new Error(
+        throw new InfrastructureError(
+            ErrorCode.DATABASE_URL_MISSING,
             'DATABASE_URL is not set. Set it in your Vercel environment variables.'
         );
     }
@@ -20,15 +22,19 @@ function validateAndLogDbUrl(): string {
         const url = new URL(dbUrl);
         const dbName = url.pathname.replace(/^\//, '');
         if (!dbName) {
-            throw new Error(
-                `DATABASE_URL is missing a database name. Current path: "${url.pathname}". Expected: "/lojacond"`
+            throw new InfrastructureError(
+                ErrorCode.DATABASE_URL_MISSING,
+                `DATABASE_URL is missing a database name. Expected: "/lojacond"`
             );
         }
         logger.info(`DB pool init: host=${url.hostname}, database=${dbName}`);
     } catch (parseErr: any) {
-        // Only rethrow our own errors; URL parse failures mean it's a bad URL format
-        if (parseErr.message.startsWith('DATABASE_URL')) throw parseErr;
-        throw new Error(`DATABASE_URL has an invalid format: ${parseErr.message}`);
+        // Only rethrow InfrastructureError; other errors become infrastructure errors too
+        if (parseErr instanceof InfrastructureError) throw parseErr;
+        throw new InfrastructureError(
+            ErrorCode.DATABASE_URL_MISSING,
+            `DATABASE_URL has an invalid format`
+        );
     }
     return dbUrl;
 }

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -5,6 +5,7 @@
 
 export enum ErrorCode {
   // Infrastructure errors
+  DATABASE_URL_MISSING = 'DATABASE_URL_MISSING',
   REDIS_CONNECTION_ERROR = 'REDIS_CONNECTION_ERROR',
   REDIS_OPERATION_ERROR = 'REDIS_OPERATION_ERROR',
   INTERNAL_ERROR = 'INTERNAL_ERROR',
@@ -96,6 +97,7 @@ export class BusinessError extends BaseError {
  * Maps error codes to friendly messages for end users.
  */
 export const userFacingMessages: Record<ErrorCode, string> = {
+  [ErrorCode.DATABASE_URL_MISSING]: 'Serviço de banco de dados indisponível. Tente novamente em alguns minutos.',
   [ErrorCode.REDIS_CONNECTION_ERROR]: 'Serviço temporariamente indisponível. Tente novamente em alguns minutos.',
   [ErrorCode.REDIS_OPERATION_ERROR]: 'Erro ao processar sua solicitação. Tente novamente.',
   [ErrorCode.TWILIO_API_ERROR]: 'Erro ao enviar mensagem. Tente novamente.',

--- a/src/infra/http/infra-error.ts
+++ b/src/infra/http/infra-error.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { BaseError, InfrastructureError } from '../errors';
+import { logger } from '../logger';
+
+/**
+ * Generate a unique request ID for tracing.
+ */
+export function makeRequestId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Structured HTTP response for infrastructure errors.
+ * Returns 503 for retryable (infrastructure) errors, 500 for others.
+ * Never leaks stack traces, URLs, or secrets.
+ */
+export function respondInfraError(error: unknown, requestId: string): NextResponse {
+  // Log the full error for debugging (internal only)
+  logger.error('Infrastructure error', error instanceof Error ? error : new Error(String(error)));
+
+  // Handle typed BaseError
+  if (error instanceof BaseError) {
+    const status = error.isRetryable ? 503 : 500;
+    const headers: Record<string, string> = {
+      'X-Request-Id': requestId,
+    };
+    if (error.isRetryable) {
+      headers['Retry-After'] = '60';
+    }
+    return NextResponse.json(
+      {
+        error: 'INFRASTRUCTURE_ERROR',
+        code: error.code,
+        retryable: error.isRetryable,
+        requestId,
+      },
+      {
+        status,
+        headers,
+      }
+    );
+  }
+
+  // Generic error (avoid leaking details)
+  return NextResponse.json(
+    {
+      error: 'INTERNAL_SERVER_ERROR',
+      requestId,
+    },
+    {
+      status: 500,
+      headers: {
+        'X-Request-Id': requestId,
+      },
+    }
+  );
+}
+
+/**
+ * Wrap a route handler with structured error handling.
+ * Usage:
+ *   export const GET = withInfraErrorHandling(async (request) => {
+ *     // handler code
+ *   });
+ */
+export function withInfraErrorHandling(
+  handler: (request: Request, requestId: string) => Promise<NextResponse>
+) {
+  return async (request: Request) => {
+    const requestId = makeRequestId();
+    try {
+      return await handler(request, requestId);
+    } catch (error) {
+      return respondInfraError(error, requestId);
+    }
+  };
+}


### PR DESCRIPTION
## Objetivo

Implementar tratamento estruturado de erros de infraestrutura sem vazar stack traces, URLs, ou secrets nas respostas HTTP.

## O que muda

### 1. Novo helper: `src/infra/http/infra-error.ts`

- **`makeRequestId()`**: Gera UUID único para rastreamento de requisições
- **`respondInfraError(error, requestId)`**: Retorna resposta estruturada:
  - `303` com code/retryable para `BaseError` (erros retentáveis de infra)
  - `500` para outros erros genéricos
  - **Nunca vaza**: stack trace, URLs, valores secretos
  - **Sempre inclui**: `X-Request-Id` header para debugging

### 2. Tipos de erro estruturado

```json
{
  "error": "INFRASTRUCTURE_ERROR",
  "code": "DATABASE_URL_MISSING",
  "retryable": true,
  "requestId": "550e8400-e29b-41d4-a716-446655440000"
}
```

### 3. Mudanças em cada arquivo

| Arquivo | Mudança |
|---------|---------|
| `src/infra/errors.ts` | Adiciona `DATABASE_URL_MISSING` ao enum ErrorCode |
| `src/infra/db.ts` | `getDb()` lança `InfrastructureError` ao invés de `Error` quando DATABASE_URL ausente |
| `/api/internal/health/db` | Adiciona requestId + respondInfraError no catch |
| `/api/cockpit/metrics` | Adiciona requestId + respondInfraError no catch |
| `/api/cockpit/metrics/funnel` | Adiciona requestId + respondInfraError no catch |

## Benefícios

✅ **Nunca vaza informações sensíveis** (stack traces, secrets, URLs)
✅ **Rastreamento de requisições** via `X-Request-Id` header
✅ **Metadados de retentativa** (`retryable: true` permite client tentar novamente)
✅ **Status code correto** (503 Service Unavailable para infra, 500 para erros genéricos)
✅ **Mensagens user-friendly** em `INTERNAL_ERROR` sem detalhes técnicos

## Validação

✅ `npm run typecheck` — zero erros
✅ `npm run build` (sem `DATABASE_URL`) — BUILD SUCCEEDS
✅ Runtime sem `DATABASE_URL`:
  - `GET /api/internal/health/db` → 503 com code `DATABASE_URL_MISSING`
  - Resposta inclui `X-Request-Id` para debugging

## Routes atualizadas

- `/api/internal/health/db` — monitora saúde do DB
- `/api/cockpit/metrics` — queries DB para métricas do tenant
- `/api/cockpit/metrics/funnel` — queries DB para funnel de freight

## Próximos passos (out of scope)

- Aplicar o mesmo padrão nas demais rotas cockpit (analytics, audit, etc.)
- Aplicar em `/api/events` e `/api/internal/exports/frank-events`
- Adicionar retry logic no client

🤖 Generated with [Claude Code](https://claude.com/claude-code)