### PR TITLE
ci: add security workflow for dependency audit and lint

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,60 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-20.x-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-20.x-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        # Fail only on high/critical severity; omit devDependencies from scope
+        run: npm audit --omit=dev --audit-level=high
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-20.x-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-20.x-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
## Objetivo

Adicionar CI de segurança mínima rodando em todo PR e push na main.

## Jobs (paralelos)

### `audit` — Dependency Audit
```bash
npm audit --omit=dev --audit-level=high
```
- Falha apenas em vulnerabilidades **high** ou **critical**
- **Exclui devDependencies** do escopo (apenas produção importa)
- Detecta supply chain attacks antes do merge

### `lint` — ESLint
```bash
npm run lint  # next lint
```
- Captura violações de ESLint antes do merge
- Usa o mesmo `next lint` já configurado no projeto

## Detalhes

| Trigger | Branches |
|---------|----------|
| `push` | `main` |
| `pull_request` | todas |

- Node.js 20.x
- Cache `~/.npm` keyed por `package-lock.json` hash (mesmo padrão do `ci.yml`)
- Dois jobs independentes e paralelos

## O que NÃO faz (intencional)

- Não roda `npm audit` em devDependencies — evita falsos positivos de ferramentas de build
- Não falha em `moderate`/`low` — mantém baixo ruído, foca no crítico

🤖 Generated with [Claude Code](https://claude.com/claude-code)