### PR TITLE
feat(metrics): harden rollup with bounded concurrency and batch upsert

### DIFF
--- a/docs/ops-cockpit.md
+++ b/docs/ops-cockpit.md
@@ -33,6 +33,10 @@ Body opcional:
 - Se `day` não for enviado, usa a regra padrão do serviço (`defaultRollupDay`).
 - A execução é limitada ao tenant da sessão admin.
 - A rota grava audit log (`ops.run_rollup`) e invalida o cache curto de status.
+- O `result` pode incluir:
+  - `failedTenants`: quantidade de tenants com erro no processamento (sempre `0` na rota manual, exceto falha retornada pelo serviço antes da resposta).
+  - `errors`: lista resumida (`tenantId`, `day`, `code`, `message`) usada em execuções multi-tenant (jobs internos).
+- O processamento multi-tenant usa paralelismo controlado por `METRICS_ROLLUP_CONCURRENCY` (default `4`) e mantém lock distribuído por `tenant + day`.
 
 ### Resposta `409 LOCK_BUSY`
 

--- a/src/app/api/cockpit/ops/run-rollup/__tests__/route.test.ts
+++ b/src/app/api/cockpit/ops/run-rollup/__tests__/route.test.ts
@@ -69,6 +69,8 @@ describe('POST /api/cockpit/ops/run-rollup', () => {
       day: '2026-02-24',
       rowsWritten: 7,
       skippedTenants: 0,
+      failedTenants: 0,
+      errors: [],
       lockBusy: false,
       durationMs: 55,
     });
@@ -158,6 +160,8 @@ describe('POST /api/cockpit/ops/run-rollup', () => {
       day: '2026-02-24',
       rowsWritten: 0,
       skippedTenants: 1,
+      failedTenants: 0,
+      errors: [],
       lockBusy: true,
       durationMs: 5,
     });

--- a/src/app/api/internal/jobs/__tests__/routes.test.ts
+++ b/src/app/api/internal/jobs/__tests__/routes.test.ts
@@ -64,6 +64,8 @@ describe('internal jobs RBAC', () => {
       day: '2026-02-24',
       rowsWritten: 3,
       skippedTenants: 0,
+      failedTenants: 0,
+      errors: [],
       lockBusy: false,
       durationMs: 10,
     });

--- a/src/modules/metrics/__tests__/metrics-daily.repository.test.ts
+++ b/src/modules/metrics/__tests__/metrics-daily.repository.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDb } from '../../../infra/db';
+import {
+  METRICS_DAILY_UPSERT_CHUNK_SIZE,
+  MetricsDailyRepository,
+  type MetricsDailyUpsertRow,
+} from '../metrics-daily.repository';
+
+const mockExecute = vi.fn();
+
+vi.mock('../../../infra/db', () => ({
+  getDb: vi.fn(),
+}));
+
+describe('MetricsDailyRepository.upsertDailyRows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockReset();
+    mockExecute.mockResolvedValue([[], []]);
+    vi.mocked(getDb).mockResolvedValue({ execute: mockExecute } as never);
+  });
+
+  it('upserts in chunks to reduce round trips', async () => {
+    const repository = new MetricsDailyRepository();
+    const totalRows = (METRICS_DAILY_UPSERT_CHUNK_SIZE * 2) + 1;
+    const rows: MetricsDailyUpsertRow[] = Array.from({ length: totalRows }, (_, index) => ({
+      tenantId: 'tenant-1',
+      dayDate: '2026-02-20',
+      utmSource: `source-${index}`,
+      utmCampaign: `campaign-${index}`,
+      totalEvents: index,
+      funnelStarted: index,
+      freightSimulations: index,
+      consumedTokens: index,
+      clickTokens: index,
+    }));
+
+    await repository.upsertDailyRows(rows);
+
+    expect(mockExecute).toHaveBeenCalledTimes(Math.ceil(totalRows / METRICS_DAILY_UPSERT_CHUNK_SIZE));
+  });
+});

--- a/src/modules/metrics/__tests__/rollup-daily.service.test.ts
+++ b/src/modules/metrics/__tests__/rollup-daily.service.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../../infra/log/logger', () => ({
 describe('rollup-daily.service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.METRICS_ROLLUP_CONCURRENCY;
     mockExecute.mockReset();
     vi.mocked(getDb).mockResolvedValue({ execute: mockExecute } as never);
     const tenant = {
@@ -98,6 +99,8 @@ describe('rollup-daily.service', () => {
     expect(result.day).toBe('2026-02-20');
     expect(result.rowsWritten).toBe(2);
     expect(result.skippedTenants).toBe(0);
+    expect(result.failedTenants).toBe(0);
+    expect(result.errors).toEqual([]);
     expect(result.lockBusy).toBe(false);
     expect(metricsDailyRepository.upsertDailyRows).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -153,18 +156,174 @@ describe('rollup-daily.service', () => {
     })).rejects.toThrow('range_too_large');
   });
 
-  it('writes error status when a tenant rollup query fails', async () => {
+  it('throws for single-tenant rollup when tenant processing fails', async () => {
     mockExecute.mockRejectedValueOnce(Object.assign(new Error('boom'), { code: 'ER_TEST_FAIL' }));
 
     await expect(runDailyMetricsRollup({
       day: '2026-02-20',
       requestId: 'req-rollup-error',
+      tenantId: 'tenant-1',
     })).rejects.toThrow('boom');
 
     expect(metricsRollupStatusRepository.upsertError).toHaveBeenCalledWith(expect.objectContaining({
       tenantId: 'tenant-1',
       errorCode: 'ER_TEST_FAIL',
     }));
+  });
+
+  it('continues processing tenant C when tenant B fails and reports tenant error summary', async () => {
+    process.env.METRICS_ROLLUP_CONCURRENCY = '1';
+    vi.mocked(tenantRepository.getAllTenants).mockResolvedValue([
+      {
+        id: 'tenant-a',
+        name: 'Tenant A',
+        twilioNumber: 'whatsapp:+5511000000001',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+      {
+        id: 'tenant-b',
+        name: 'Tenant B',
+        twilioNumber: 'whatsapp:+5511000000002',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+      {
+        id: 'tenant-c',
+        name: 'Tenant C',
+        twilioNumber: 'whatsapp:+5511000000003',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+    ] as never);
+    mockExecute.mockResolvedValue([[], []]);
+
+    let upsertCallCount = 0;
+    vi.mocked(metricsDailyRepository.upsertDailyRows).mockImplementation(async () => {
+      upsertCallCount += 1;
+      if (upsertCallCount === 2) {
+        throw Object.assign(new Error('tenant-b failed'), { code: 'ER_TENANT_B' });
+      }
+    });
+
+    const result = await runDailyMetricsRollup({
+      day: '2026-02-20',
+      requestId: 'req-rollup-continue-on-error',
+    });
+
+    expect(result.rowsWritten).toBe(0);
+    expect(result.skippedTenants).toBe(0);
+    expect(result.failedTenants).toBe(1);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        tenantId: 'tenant-b',
+        day: '2026-02-20',
+        code: 'ER_TENANT_B',
+        message: 'tenant-b failed',
+      }),
+    ]);
+    expect(vi.mocked(metricsDailyRepository.upsertDailyRows)).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(metricsRollupStatusRepository.upsertError)).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-b',
+      errorCode: 'ER_TENANT_B',
+    }));
+    expect(vi.mocked(metricsRollupStatusRepository.upsertSuccess)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(metricsRollupStatusRepository.upsertSuccess)).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      tenantId: 'tenant-a',
+    }));
+    expect(vi.mocked(metricsRollupStatusRepository.upsertSuccess)).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      tenantId: 'tenant-c',
+    }));
+  });
+
+  it('respects METRICS_ROLLUP_CONCURRENCY limit when processing tenants', async () => {
+    process.env.METRICS_ROLLUP_CONCURRENCY = '2';
+    vi.mocked(tenantRepository.getAllTenants).mockResolvedValue([
+      {
+        id: 'tenant-1',
+        name: 'Tenant 1',
+        twilioNumber: 'whatsapp:+5511000000001',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+      {
+        id: 'tenant-2',
+        name: 'Tenant 2',
+        twilioNumber: 'whatsapp:+5511000000002',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+      {
+        id: 'tenant-3',
+        name: 'Tenant 3',
+        twilioNumber: 'whatsapp:+5511000000003',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+      {
+        id: 'tenant-4',
+        name: 'Tenant 4',
+        twilioNumber: 'whatsapp:+5511000000004',
+        timezone: 'America/Sao_Paulo',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: null,
+        planStatus: null,
+        planCurrentPeriodEnd: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+    ] as never);
+    mockExecute.mockResolvedValue([[], []]);
+
+    let active = 0;
+    let maxActive = 0;
+    vi.mocked(metricsDailyRepository.upsertDailyRows).mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      active -= 1;
+    });
+
+    const result = await runDailyMetricsRollup({
+      day: '2026-02-20',
+      requestId: 'req-rollup-concurrency',
+    });
+
+    expect(result.failedTenants).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(vi.mocked(metricsDailyRepository.upsertDailyRows)).toHaveBeenCalledTimes(4);
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(maxActive).toBe(2);
   });
 
   it('skips tenant when lock is busy and marks lock-busy status', async () => {
@@ -178,6 +337,8 @@ describe('rollup-daily.service', () => {
 
     expect(result.rowsWritten).toBe(0);
     expect(result.skippedTenants).toBe(1);
+    expect(result.failedTenants).toBe(0);
+    expect(result.errors).toEqual([]);
     expect(result.lockBusy).toBe(true);
     expect(metricsDailyRepository.upsertDailyRows).not.toHaveBeenCalled();
     expect(metricsRollupStatusRepository.markLockBusy).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/modules/metrics/metrics-daily.repository.ts
+++ b/src/modules/metrics/metrics-daily.repository.ts
@@ -25,6 +25,8 @@ export interface MetricsDailyUpsertRow {
   clickTokens: number;
 }
 
+export const METRICS_DAILY_UPSERT_CHUNK_SIZE = 250;
+
 function normalizeBucketValue(value: string | null | undefined): string {
   const trimmed = value?.trim() ?? '';
   return trimmed || '(none)';
@@ -38,6 +40,16 @@ function toInt(value: unknown): number {
 function isTableMissingMetricsDaily(error: unknown): boolean {
   const e = error as { code?: string; message?: string };
   return e?.code === 'ER_NO_SUCH_TABLE' || Boolean(e?.message?.toLowerCase().includes('metrics_daily'));
+}
+
+function chunkRows<T>(rows: T[], chunkSize: number): T[][] {
+  if (rows.length === 0) return [];
+  const size = Math.max(1, Math.trunc(chunkSize));
+  const chunks: T[][] = [];
+  for (let i = 0; i < rows.length; i += size) {
+    chunks.push(rows.slice(i, i + size));
+  }
+  return chunks;
 }
 
 export class MetricsDailyRepository {
@@ -88,8 +100,34 @@ export class MetricsDailyRepository {
   async upsertDailyRows(rows: MetricsDailyUpsertRow[]): Promise<void> {
     if (rows.length === 0) return;
     const db = await getDb();
+    const normalized = rows.map((row) => ({
+      tenantId: row.tenantId,
+      dayDate: row.dayDate,
+      utmSource: normalizeBucketValue(row.utmSource),
+      utmCampaign: normalizeBucketValue(row.utmCampaign),
+      totalEvents: toInt(row.totalEvents),
+      funnelStarted: toInt(row.funnelStarted),
+      freightSimulations: toInt(row.freightSimulations),
+      consumedTokens: toInt(row.consumedTokens),
+      clickTokens: toInt(row.clickTokens),
+    }));
 
-    for (const row of rows) {
+    for (const chunk of chunkRows(normalized, METRICS_DAILY_UPSERT_CHUNK_SIZE)) {
+      const valuesSql = sql.join(
+        chunk.map((row) => sql`(
+          ${row.tenantId},
+          ${row.dayDate},
+          ${row.utmSource},
+          ${row.utmCampaign},
+          ${row.totalEvents},
+          ${row.funnelStarted},
+          ${row.freightSimulations},
+          ${row.consumedTokens},
+          ${row.clickTokens}
+        )`),
+        sql`, `,
+      );
+
       await db.execute(sql`
         INSERT INTO metrics_daily (
           tenant_id,
@@ -101,17 +139,7 @@ export class MetricsDailyRepository {
           freight_simulations,
           consumed_tokens,
           click_tokens
-        ) VALUES (
-          ${row.tenantId},
-          ${row.dayDate},
-          ${normalizeBucketValue(row.utmSource)},
-          ${normalizeBucketValue(row.utmCampaign)},
-          ${toInt(row.totalEvents)},
-          ${toInt(row.funnelStarted)},
-          ${toInt(row.freightSimulations)},
-          ${toInt(row.consumedTokens)},
-          ${toInt(row.clickTokens)}
-        )
+        ) VALUES ${valuesSql}
         ON DUPLICATE KEY UPDATE
           total_events = VALUES(total_events),
           funnel_started = VALUES(funnel_started),

--- a/src/modules/metrics/rollup-daily.service.ts
+++ b/src/modules/metrics/rollup-daily.service.ts
@@ -30,10 +30,28 @@ interface TenantRollupResult {
   durationMs: number;
 }
 
+export interface RollupTenantErrorSummary {
+  tenantId: string;
+  day: string;
+  code: string;
+  message: string;
+}
+
+interface TenantRollupOutcome {
+  tenantId: string;
+  timezone: string;
+  rowsWritten: number;
+  durationMs: number;
+  skipped: boolean;
+  error: RollupTenantErrorSummary | null;
+}
+
 export interface RollupDailyResult {
   day: string;
   rowsWritten: number;
   skippedTenants: number;
+  failedTenants: number;
+  errors: RollupTenantErrorSummary[];
   lockBusy: boolean;
   durationMs: number;
 }
@@ -49,6 +67,9 @@ export interface RollupBackfillResult {
 }
 
 const TENANT_DAY_ROLLUP_LOCK_TTL_SEC = 10 * 60;
+const DEFAULT_ROLLUP_CONCURRENCY = 4;
+const MIN_ROLLUP_CONCURRENCY = 1;
+const MAX_ROLLUP_CONCURRENCY = 16;
 
 const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -121,6 +142,48 @@ function inferRollupErrorCode(error: unknown): string {
   }
 
   return 'ROLLUP_ERROR';
+}
+
+function inferRollupErrorMessage(error: unknown): string {
+  const e = error as { message?: string };
+  const message = typeof e?.message === 'string' ? e.message.trim() : '';
+  if (!message) return 'Rollup failed';
+  return message.slice(0, 240);
+}
+
+function getRollupConcurrencyLimit(): number {
+  const raw = process.env.METRICS_ROLLUP_CONCURRENCY?.trim();
+  const parsed = Number(raw);
+  if (!raw || !Number.isFinite(parsed)) {
+    return DEFAULT_ROLLUP_CONCURRENCY;
+  }
+  return Math.min(MAX_ROLLUP_CONCURRENCY, Math.max(MIN_ROLLUP_CONCURRENCY, Math.trunc(parsed)));
+}
+
+async function mapWithConcurrencyLimit<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+
+  const normalizedLimit = Math.min(items.length, Math.max(1, Math.trunc(limit)));
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const runWorker = async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await worker(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: normalizedLimit }, () => runWorker()));
+  return results;
 }
 
 async function queryAggregateRowsForTenant(
@@ -247,6 +310,175 @@ function applyPatch(
   }
 }
 
+async function processTenantDailyMetricsRollup(input: {
+  tenant: Awaited<ReturnType<typeof tenantRepository.getAllTenants>>[number];
+  day: string;
+  requestId?: string;
+}): Promise<TenantRollupOutcome> {
+  const tenantStartedAt = Date.now();
+  const tenant = input.tenant;
+  const day = input.day;
+  const timezone = normalizeTenantTimeZone(tenant.timezone);
+  const bounds = getLocalDayBounds(day, timezone);
+  const merged = new Map<string, MetricsDailyUpsertRow>();
+  const lockKey = `rollup:lock:${tenant.id}:${day}`;
+  let lockAcquired = false;
+  let lockToken = '';
+
+  structuredLogger.info('metrics_rollup_daily_tenant_start', {
+    requestId: input.requestId,
+    eventType: 'metrics_rollup_daily_tenant',
+    tenantId: tenant.id,
+    timezone,
+    day,
+    startUTC: bounds.startUTC.toISOString(),
+    endUTC: bounds.endUTC.toISOString(),
+  });
+
+  try {
+    const lock = await acquireLock(lockKey, TENANT_DAY_ROLLUP_LOCK_TTL_SEC);
+    lockAcquired = lock.acquired;
+    lockToken = lock.token;
+
+    if (!lock.acquired) {
+      await metricsRollupStatusRepository.markLockBusy({
+        tenantId: tenant.id,
+        runAt: new Date(),
+      });
+      const durationMs = Date.now() - tenantStartedAt;
+      structuredLogger.warn('rollup_lock_busy', {
+        requestId: input.requestId,
+        eventType: 'metrics_rollup_daily_lock',
+        tenantId: tenant.id,
+        timezone,
+        day,
+        lockKey,
+        ttlSec: TENANT_DAY_ROLLUP_LOCK_TTL_SEC,
+        durationMs,
+        outcome: 'skipped',
+      });
+
+      return {
+        tenantId: tenant.id,
+        timezone,
+        rowsWritten: 0,
+        durationMs,
+        skipped: true,
+        error: null,
+      };
+    }
+
+    const aggregates = await queryAggregateRowsForTenant(tenant.id, bounds);
+
+    applyPatch(merged, day, aggregates.publicEvents, (count) => ({ totalEvents: count }));
+    applyPatch(merged, day, aggregates.funnelStarted, (count) => ({ funnelStarted: count }));
+    applyPatch(merged, day, aggregates.freightSimulations, (count) => ({ freightSimulations: count }));
+    applyPatch(merged, day, aggregates.clickTokens, (count) => ({ clickTokens: count }));
+    applyPatch(merged, day, aggregates.consumedTokens, (count) => ({ consumedTokens: count }));
+
+    const tenantRowsToUpsert = Array.from(merged.values());
+    await metricsDailyRepository.upsertDailyRows(tenantRowsToUpsert);
+
+    const tenantResult: TenantRollupResult = {
+      tenantId: tenant.id,
+      timezone,
+      rowsWritten: tenantRowsToUpsert.length,
+      durationMs: Date.now() - tenantStartedAt,
+    };
+
+    await metricsRollupStatusRepository.upsertSuccess({
+      tenantId: tenant.id,
+      day,
+      runAt: new Date(),
+      durationMs: tenantResult.durationMs,
+      rowsWritten: tenantResult.rowsWritten,
+    });
+
+    structuredLogger.info('metrics_rollup_daily_tenant_end', {
+      requestId: input.requestId,
+      eventType: 'metrics_rollup_daily_tenant',
+      tenantId: tenantResult.tenantId,
+      timezone: tenantResult.timezone,
+      day,
+      rowsWritten: tenantResult.rowsWritten,
+      durationMs: tenantResult.durationMs,
+      outcome: 'ok',
+    });
+
+    return {
+      tenantId: tenantResult.tenantId,
+      timezone: tenantResult.timezone,
+      rowsWritten: tenantResult.rowsWritten,
+      durationMs: tenantResult.durationMs,
+      skipped: false,
+      error: null,
+    };
+  } catch (error) {
+    const errorCode = inferRollupErrorCode(error);
+    const errorMessage = inferRollupErrorMessage(error);
+    try {
+      await metricsRollupStatusRepository.upsertError({
+        tenantId: tenant.id,
+        runAt: new Date(),
+        errorCode,
+      });
+    } catch (statusError) {
+      structuredLogger.error('metrics_rollup_daily_tenant_status_error', {
+        requestId: input.requestId,
+        tenantId: tenant.id,
+        timezone,
+        day,
+        eventType: 'metrics_rollup_daily_tenant',
+        errorCode: inferRollupErrorCode(statusError),
+        error: statusError,
+      });
+    }
+
+    const durationMs = Date.now() - tenantStartedAt;
+    structuredLogger.error('metrics_rollup_daily_tenant_failed', {
+      requestId: input.requestId,
+      tenantId: tenant.id,
+      timezone,
+      day,
+      eventType: 'metrics_rollup_daily_tenant',
+      durationMs,
+      errorCode,
+      error,
+    });
+
+    return {
+      tenantId: tenant.id,
+      timezone,
+      rowsWritten: 0,
+      durationMs,
+      skipped: false,
+      error: {
+        tenantId: tenant.id,
+        day,
+        code: errorCode,
+        message: errorMessage,
+      },
+    };
+  } finally {
+    if (lockAcquired) {
+      try {
+        await releaseLock(lockKey, lockToken);
+      } catch (releaseError) {
+        structuredLogger.error('rollup_lock_release_failed', {
+          requestId: input.requestId,
+          eventType: 'metrics_rollup_daily_lock',
+          tenantId: tenant.id,
+          timezone,
+          day,
+          lockKey,
+          errorCode: inferRollupErrorCode(releaseError),
+          error: releaseError,
+        });
+      }
+    }
+  }
+}
+
 export async function runDailyMetricsRollup(input: {
   day?: string | null;
   tenantId?: string | null;
@@ -261,9 +493,10 @@ export async function runDailyMetricsRollup(input: {
     eventType: 'metrics_rollup_daily',
     day,
     tenantId: input.tenantId ?? undefined,
+    concurrency: getRollupConcurrencyLimit(),
   });
 
-  const tenantRows = input.tenantId?.trim()
+  const tenants = await (input.tenantId?.trim()
     ? (() => {
         const tenantId = input.tenantId!.trim();
         return tenantRepository.getTenantById(tenantId).then((tenant) => {
@@ -271,150 +504,57 @@ export async function runDailyMetricsRollup(input: {
           return [tenant];
         });
       })()
-    : tenantRepository.getAllTenants();
+    : tenantRepository.getAllTenants());
 
-  let totalRowsWritten = 0;
-  let skippedTenants = 0;
+  const concurrency = input.tenantId?.trim()
+    ? 1
+    : Math.min(tenants.length || 1, getRollupConcurrencyLimit());
 
-  for (const tenant of await tenantRows) {
-    const tenantStartedAt = Date.now();
-    const timezone = normalizeTenantTimeZone(tenant.timezone);
-    const bounds = getLocalDayBounds(day, timezone);
-    const merged = new Map<string, MetricsDailyUpsertRow>();
-    const lockKey = `rollup:lock:${tenant.id}:${day}`;
-    let lockAcquired = false;
-    let lockToken = '';
-
-    structuredLogger.info('metrics_rollup_daily_tenant_start', {
-      requestId: input.requestId,
-      eventType: 'metrics_rollup_daily_tenant',
-      tenantId: tenant.id,
-      timezone,
+  const tenantOutcomes = await mapWithConcurrencyLimit(
+    tenants,
+    concurrency,
+    (tenant) => processTenantDailyMetricsRollup({
+      tenant,
       day,
-      startUTC: bounds.startUTC.toISOString(),
-      endUTC: bounds.endUTC.toISOString(),
-    });
+      requestId: input.requestId,
+    }),
+  );
 
-    try {
-      const lock = await acquireLock(lockKey, TENANT_DAY_ROLLUP_LOCK_TTL_SEC);
-      lockAcquired = lock.acquired;
-      lockToken = lock.token;
-
-      if (!lock.acquired) {
-        skippedTenants += 1;
-        await metricsRollupStatusRepository.markLockBusy({
-          tenantId: tenant.id,
-          runAt: new Date(),
-        });
-        structuredLogger.warn('rollup_lock_busy', {
-          requestId: input.requestId,
-          eventType: 'metrics_rollup_daily_lock',
-          tenantId: tenant.id,
-          timezone,
-          day,
-          lockKey,
-          ttlSec: TENANT_DAY_ROLLUP_LOCK_TTL_SEC,
-          outcome: 'skipped',
-        });
-        continue;
-      }
-
-      const aggregates = await queryAggregateRowsForTenant(tenant.id, bounds);
-
-      applyPatch(merged, day, aggregates.publicEvents, (count) => ({ totalEvents: count }));
-      applyPatch(merged, day, aggregates.funnelStarted, (count) => ({ funnelStarted: count }));
-      applyPatch(merged, day, aggregates.freightSimulations, (count) => ({ freightSimulations: count }));
-      applyPatch(merged, day, aggregates.clickTokens, (count) => ({ clickTokens: count }));
-      applyPatch(merged, day, aggregates.consumedTokens, (count) => ({ consumedTokens: count }));
-
-      const tenantRowsToUpsert = Array.from(merged.values());
-      await metricsDailyRepository.upsertDailyRows(tenantRowsToUpsert);
-
-      const tenantResult: TenantRollupResult = {
-        tenantId: tenant.id,
-        timezone,
-        rowsWritten: tenantRowsToUpsert.length,
-        durationMs: Date.now() - tenantStartedAt,
-      };
-
-      totalRowsWritten += tenantResult.rowsWritten;
-      await metricsRollupStatusRepository.upsertSuccess({
-        tenantId: tenant.id,
-        day,
-        runAt: new Date(),
-        durationMs: tenantResult.durationMs,
-        rowsWritten: tenantResult.rowsWritten,
-      });
-
-      structuredLogger.info('metrics_rollup_daily_tenant_end', {
-        requestId: input.requestId,
-        eventType: 'metrics_rollup_daily_tenant',
-        tenantId: tenantResult.tenantId,
-        timezone: tenantResult.timezone,
-        day,
-        rowsWritten: tenantResult.rowsWritten,
-        durationMs: tenantResult.durationMs,
-        rowsAccumulated: totalRowsWritten,
-        outcome: 'ok',
-      });
-    } catch (error) {
-      const errorCode = inferRollupErrorCode(error);
-      try {
-        await metricsRollupStatusRepository.upsertError({
-          tenantId: tenant.id,
-          runAt: new Date(),
-          errorCode,
-        });
-      } catch (statusError) {
-        structuredLogger.error('metrics_rollup_daily_tenant_status_error', {
-          requestId: input.requestId,
-          tenantId: tenant.id,
-          timezone,
-          day,
-          eventType: 'metrics_rollup_daily_tenant',
-          errorCode: inferRollupErrorCode(statusError),
-          error: statusError,
-        });
-      }
-
-      structuredLogger.error('metrics_rollup_daily_tenant_failed', {
-        requestId: input.requestId,
-        tenantId: tenant.id,
-        timezone,
-        day,
-        eventType: 'metrics_rollup_daily_tenant',
-        durationMs: Date.now() - tenantStartedAt,
-        errorCode,
-        error,
-      });
-      throw error;
-    } finally {
-      if (lockAcquired) {
-        try {
-          await releaseLock(lockKey, lockToken);
-        } catch (releaseError) {
-          structuredLogger.error('rollup_lock_release_failed', {
-            requestId: input.requestId,
-            eventType: 'metrics_rollup_daily_lock',
-            tenantId: tenant.id,
-            timezone,
-            day,
-            lockKey,
-            errorCode: inferRollupErrorCode(releaseError),
-            error: releaseError,
-          });
-        }
-      }
-    }
-  }
+  const errors = tenantOutcomes
+    .map((outcome) => outcome.error)
+    .filter((error): error is RollupTenantErrorSummary => Boolean(error));
+  const totalRowsWritten = tenantOutcomes.reduce((sum, outcome) => sum + outcome.rowsWritten, 0);
+  const skippedTenants = tenantOutcomes.reduce((sum, outcome) => sum + (outcome.skipped ? 1 : 0), 0);
 
   const result: RollupDailyResult = {
     day,
     rowsWritten: totalRowsWritten,
     skippedTenants,
+    failedTenants: errors.length,
+    errors,
     lockBusy: Boolean(input.tenantId?.trim()) && skippedTenants > 0 && totalRowsWritten === 0,
     durationMs: Date.now() - startedAt,
   };
+
+  if (input.tenantId?.trim() && errors.length > 0) {
+    const firstError = errors[0];
+    structuredLogger.error('metrics_rollup_daily_end', {
+      requestId: input.requestId,
+      eventType: 'metrics_rollup_daily',
+      day,
+      tenantId: input.tenantId ?? undefined,
+      rowsWritten: result.rowsWritten,
+      skippedTenants: result.skippedTenants,
+      failedTenants: result.failedTenants,
+      lockBusy: result.lockBusy,
+      durationMs: result.durationMs,
+      errors,
+      outcome: 'error',
+    });
+    const error = new Error(firstError.message);
+    (error as Error & { code?: string }).code = firstError.code;
+    throw error;
+  }
 
   structuredLogger.info('metrics_rollup_daily_end', {
     requestId: input.requestId,
@@ -423,9 +563,11 @@ export async function runDailyMetricsRollup(input: {
     tenantId: input.tenantId ?? undefined,
     rowsWritten: result.rowsWritten,
     skippedTenants: result.skippedTenants,
+    failedTenants: result.failedTenants,
     lockBusy: result.lockBusy,
     durationMs: result.durationMs,
-    outcome: 'ok',
+    errors,
+    outcome: errors.length > 0 ? 'partial_error' : 'ok',
   });
 
   return result;


### PR DESCRIPTION
## Summary
- R1: unDailyMetricsRollup now continues on per-tenant errors (multi-tenant runs) and returns aggregated tenant error summaries (	enantId, day, code, message).
- Manus Risk A: added bounded tenant concurrency via METRICS_ROLLUP_CONCURRENCY (default 4, clamped 1..16) with existing distributed lock behavior preserved (LOCK_BUSY counted as skipped).
- R4: metrics_daily upserts now run in batch chunks (250 rows/chunk) using INSERT ... VALUES (...), (...) ON DUPLICATE KEY UPDATE, preserving idempotency.
- Added tests for error isolation, concurrency limit enforcement, and batch chunking; adjusted route tests for the expanded rollup summary shape.
- Updated docs/ops-cockpit.md (manual rollup summary + concurrency note).

## Expected Runtime Impact
- Lower DB round trips during rollup writes due to chunked batch upsert (significant improvement when many attribution buckets exist).
- Faster multi-tenant daily runs via bounded parallelism while avoiding unbounded Promise.all fan-out.
- Partial failures no longer abort the whole tenant batch, improving operational robustness and reducing re-run scope.

## Validation
- 
pm run typecheck ✅
- 
pm test ✅

## Staging Validation
1. Trigger internal daily rollup for a day with multiple active tenants and confirm response includes ailedTenants/rrors only when applicable.
2. Trigger manual cockpit rollup and confirm 409 LOCK_BUSY behavior is unchanged if the same tenant/day is already running.
3. Check logs for metrics_rollup_daily_tenant_* and ollup_lock_busy events with equestId/	enantId.
4. Compare metrics_rollup_status updates for success/error tenants after a mixed-result run.
5. Verify metrics_daily rows remain idempotent by re-running the same day and comparing counts.