### PR TITLE
fix(auth): unblock login when redis down (fallback local limiter for auth.login)

### DIFF
--- a/src/infra/security/__tests__/rate-limiter.test.ts
+++ b/src/infra/security/__tests__/rate-limiter.test.ts
@@ -33,13 +33,14 @@ vi.mock('../../attribution/hash', () => ({
   sha256Hex: mockSha256Hex,
 }));
 
-import { RateLimiter } from '../rate-limiter';
+import { RateLimiter, resetRateLimiterState } from '../rate-limiter';
 
 describe('security rate-limiter redis failure hardening', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-02-25T12:00:00.000Z'));
+    resetRateLimiterState();
 
     vi.stubEnv('NODE_ENV', 'production');
     delete process.env.RATE_LIMIT_FAIL_CLOSED;
@@ -62,7 +63,8 @@ describe('security rate-limiter redis failure hardening', () => {
     const limiter = new RateLimiter();
     const now = Date.now();
 
-    const result = await limiter.limit('auth.login', '1.2.3.4:user@example.com', {
+    // Use a scope that is NOT in FAILOPEN_WITH_MEMORY_SCOPES (e.g. internal.ops)
+    const result = await limiter.limit('internal.ops', '1.2.3.4:admin', {
       max: 5,
       windowSec: 60,
     });
@@ -77,7 +79,7 @@ describe('security rate-limiter redis failure hardening', () => {
       'rate_limiter_redis_failure_fail_closed',
       expect.objectContaining({
         eventType: 'rate_limiter',
-        scope: 'auth.login',
+        scope: 'internal.ops',
         keyHash: '0123456789abcdef',
         reason: 'redis_unavailable',
         rateLimitMode: 'fail_closed',
@@ -87,7 +89,56 @@ describe('security rate-limiter redis failure hardening', () => {
 
     const logContext = mockStructuredLogger.error.mock.calls[0]?.[1];
     expect(logContext).not.toHaveProperty('key');
-    expect(JSON.stringify(logContext)).not.toContain('user@example.com');
+    expect(JSON.stringify(logContext)).not.toContain('admin');
+  });
+
+  it('uses memory fallback for auth.login (failopen scope) when redis is unavailable', async () => {
+    const limiter = new RateLimiter();
+
+    const result = await limiter.limit('auth.login', '1.2.3.4:user@example.com', {
+      max: 5,
+      windowSec: 60,
+    });
+
+    // Should be allowed (memory fallback, first request)
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBeGreaterThan(0);
+    expect(mockStructuredLogger.warn).toHaveBeenCalledWith(
+      'rate_limiter_fallback_local_used',
+      expect.objectContaining({
+        eventType: 'rate_limiter',
+        scope: 'auth.login',
+        reason: 'redis_unavailable',
+        rateLimitMode: 'failopen_memory',
+        sensitivity: 'failopen_memory',
+      }),
+    );
+    // Must NOT call fail_closed for auth.login
+    expect(mockStructuredLogger.error).not.toHaveBeenCalledWith(
+      'rate_limiter_redis_failure_fail_closed',
+      expect.anything(),
+    );
+  });
+
+  it('auth.login memory fallback still rate-limits after exceeding max', async () => {
+    const limiter = new RateLimiter();
+
+    // Exhaust the limit (5 requests)
+    for (let i = 0; i < 5; i++) {
+      await limiter.limit('auth.login', '1.2.3.4:brute', {
+        max: 5,
+        windowSec: 60,
+      });
+    }
+
+    // 6th request should be blocked
+    const result = await limiter.limit('auth.login', '1.2.3.4:brute', {
+      max: 5,
+      windowSec: 60,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
   });
 
   it('fails open for public_safe scopes when redis is unavailable', async () => {
@@ -123,7 +174,7 @@ describe('security rate-limiter redis failure hardening', () => {
     mockRedis.get.mockResolvedValue(0);
 
     const limiter = new RateLimiter();
-    const result = await limiter.limit('auth.login', '1.2.3.4:user@example.com', {
+    const result = await limiter.limit('internal.ops', '1.2.3.4:admin', {
       max: 5,
       windowSec: 60,
     });
@@ -134,13 +185,40 @@ describe('security rate-limiter redis failure hardening', () => {
       'rate_limiter_redis_failure_fail_closed',
       expect.objectContaining({
         eventType: 'rate_limiter',
-        scope: 'auth.login',
+        scope: 'internal.ops',
         keyHash: '0123456789abcdef',
         reason: 'redis_error',
         rateLimitMode: 'fail_closed',
         sensitivity: 'critical',
         errorName: 'Error',
       }),
+    );
+  });
+
+  it('auth.login uses memory fallback even when redis errors (not just unavailable)', async () => {
+    mockRedis.isAvailable.mockReturnValue(true);
+    mockRedis.incr.mockResolvedValue(0);
+    mockRedis.get.mockResolvedValue(0);
+
+    const limiter = new RateLimiter();
+    const result = await limiter.limit('auth.login', '1.2.3.4:user@example.com', {
+      max: 5,
+      windowSec: 60,
+    });
+
+    // Should use memory fallback, not fail-closed
+    expect(result.allowed).toBe(true);
+    expect(mockStructuredLogger.warn).toHaveBeenCalledWith(
+      'rate_limiter_fallback_local_used',
+      expect.objectContaining({
+        scope: 'auth.login',
+        reason: 'redis_error',
+        rateLimitMode: 'failopen_memory',
+      }),
+    );
+    expect(mockStructuredLogger.error).not.toHaveBeenCalledWith(
+      'rate_limiter_redis_failure_fail_closed',
+      expect.anything(),
     );
   });
 });

--- a/src/infra/security/rate-limiter.ts
+++ b/src/infra/security/rate-limiter.ts
@@ -16,12 +16,22 @@ interface LimitOptions {
   blockSec?: number;
 }
 
-export type RouteSensitivity = 'critical' | 'public_safe';
+export type RouteSensitivity = 'critical' | 'public_safe' | 'failopen_memory';
 
 /** Scopes explicitly classified as safe for fail-open on Redis failure */
 const SAFE_PUBLIC_SCOPES = new Set([
   'public_home', 'public_docs', 'public_pricing', 'public_robots', 'public_sitemap',
   'cotacao_intent', 'cotacao_quotes'
+]);
+
+/**
+ * Scopes that use in-memory fallback (NOT fail-closed) when Redis is down,
+ * even in production. These are user-facing auth flows where blocking everyone
+ * with 429 is worse than allowing through with local-only rate limiting.
+ * Critical scopes (webhooks, internal, purge-user) remain fail-closed.
+ */
+const FAILOPEN_WITH_MEMORY_SCOPES = new Set([
+  'auth.login',
 ]);
 
 interface MemoryBucket {
@@ -33,10 +43,20 @@ interface MemoryBlock {
   until: number;
 }
 
+// ─── Circuit breaker for Redis ────────────────────────────────────────────
+interface CircuitBreakerState {
+  consecutiveFailures: number;
+  openUntil: number; // timestamp ms — skip Redis until this time
+}
+
+const CIRCUIT_BREAKER_THRESHOLD = 3;  // open after N consecutive failures
+const CIRCUIT_BREAKER_COOLDOWN_MS = 30_000; // skip Redis for 30s once open
+
 const globalForRateLimiter = globalThis as typeof globalThis & {
   __condstoreRateLimiterBuckets?: Map<string, MemoryBucket>;
   __condstoreRateLimiterBlocks?: Map<string, MemoryBlock>;
   __condstoreRateLimiterFallbackMetrics?: { count: number; lastSeenAt: number | null };
+  __condstoreRateLimiterCircuitBreaker?: CircuitBreakerState;
 };
 
 const memoryBuckets =
@@ -51,8 +71,42 @@ const fallbackMetrics =
   globalForRateLimiter.__condstoreRateLimiterFallbackMetrics ??
   (globalForRateLimiter.__condstoreRateLimiterFallbackMetrics = { count: 0, lastSeenAt: null });
 
+const circuitBreaker =
+  globalForRateLimiter.__condstoreRateLimiterCircuitBreaker ??
+  (globalForRateLimiter.__condstoreRateLimiterCircuitBreaker = { consecutiveFailures: 0, openUntil: 0 });
+
+function isCircuitBreakerOpen(now: number): boolean {
+  return circuitBreaker.openUntil > now;
+}
+
+function recordRedisSuccess(): void {
+  circuitBreaker.consecutiveFailures = 0;
+}
+
+function recordRedisFailure(now: number): void {
+  circuitBreaker.consecutiveFailures += 1;
+  if (circuitBreaker.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+    circuitBreaker.openUntil = now + CIRCUIT_BREAKER_COOLDOWN_MS;
+    structuredLogger.warn('rate_limiter_circuit_breaker_open', {
+      eventType: 'rate_limiter',
+      consecutiveFailures: circuitBreaker.consecutiveFailures,
+      cooldownMs: CIRCUIT_BREAKER_COOLDOWN_MS,
+    });
+  }
+}
+
 export function getRateLimiterFallbackMetrics() {
   return { ...fallbackMetrics };
+}
+
+/** Reset all in-memory state (for testing). */
+export function resetRateLimiterState(): void {
+  memoryBuckets.clear();
+  memoryBlocks.clear();
+  fallbackMetrics.count = 0;
+  fallbackMetrics.lastSeenAt = null;
+  circuitBreaker.consecutiveFailures = 0;
+  circuitBreaker.openUntil = 0;
 }
 
 function nowMs(): number {
@@ -147,10 +201,22 @@ export class RateLimiter {
 
     const now = nowMs();
 
+    // Circuit breaker: skip Redis entirely for failopen scopes when breaker is open
+    if (FAILOPEN_WITH_MEMORY_SCOPES.has(normalizedScope) && isCircuitBreakerOpen(now)) {
+      structuredLogger.info('rate_limiter_circuit_breaker_skip_redis', {
+        eventType: 'rate_limiter',
+        scope: normalizedScope,
+      });
+      return this.limitWithMemory(normalizedScope, normalizedKey, options, now);
+    }
+
     if (redisClient.isAvailable()) {
       try {
-        return await this.limitWithRedis(normalizedScope, normalizedKey, options, now);
+        const decision = await this.limitWithRedis(normalizedScope, normalizedKey, options, now);
+        recordRedisSuccess();
+        return decision;
       } catch (error) {
+        recordRedisFailure(now);
         return await this.handleRedisFailure(normalizedScope, normalizedKey, options, now, 'redis_error', error);
       }
     }
@@ -159,6 +225,7 @@ export class RateLimiter {
       return this.limitWithMemory(normalizedScope, normalizedKey, options, now);
     }
 
+    recordRedisFailure(now);
     return await this.handleRedisFailure(normalizedScope, normalizedKey, options, now, 'redis_unavailable');
   }
 
@@ -232,7 +299,27 @@ export class RateLimiter {
   ): Promise<RateLimitDecision> {
     const keyHash = hashRateLimitKeyInternal(key);
     const errorName = error instanceof Error ? error.name : undefined;
-    const sensitivity: RouteSensitivity = SAFE_PUBLIC_SCOPES.has(scope) ? 'public_safe' : 'critical';
+    const sensitivity: RouteSensitivity = FAILOPEN_WITH_MEMORY_SCOPES.has(scope)
+      ? 'failopen_memory'
+      : SAFE_PUBLIC_SCOPES.has(scope)
+        ? 'public_safe'
+        : 'critical';
+
+    // Failopen-with-memory scopes (auth_login): use in-memory fallback even in production
+    if (sensitivity === 'failopen_memory') {
+      fallbackMetrics.count += 1;
+      fallbackMetrics.lastSeenAt = now;
+      structuredLogger.warn('rate_limiter_fallback_local_used', {
+        eventType: 'rate_limiter',
+        scope,
+        keyHash,
+        reason,
+        rateLimitMode: 'failopen_memory',
+        sensitivity,
+        ...(errorName ? { errorName } : {}),
+      });
+      return this.limitWithMemory(scope, key, options, now);
+    }
 
     if (isMemoryFallbackEnabled()) {
       structuredLogger.warn('rate_limiter_redis_failure_memory_fallback', {
@@ -246,7 +333,7 @@ export class RateLimiter {
       return this.limitWithMemory(scope, key, options, now);
     }
 
-    // P0: Default to fail-closed for critical scopes (webhook, auth, internal, ingest)
+    // P0: Default to fail-closed for critical scopes (webhook, internal, ingest)
     if (sensitivity === 'critical') {
       structuredLogger.error('rate_limiter_redis_failure_fail_closed', {
         eventType: 'rate_limiter',


### PR DESCRIPTION
## Problem
In production, /api/auth/login returns 429 for ALL users when Redis is unavailable. The rate limiter uses fail-closed mode for all non-public scopes, including auth.login.

Logs show: rate_limiter_redis_failure_fail_closed with scope: "auth.login", reason: "redis unavailable".

## Fix
* auth.login scope now uses **in-memory fallback** even in production when Redis is down
* * In-memory fallback still rate-limits to prevent brute force
* * **Circuit breaker**: after 3 consecutive Redis failures, skip Redis for 30s
* * Critical scopes (webhook, internal, purge-user) remain **fail-closed**
## Files Changed
* src/infra/security/rate-limiter.ts
* * src/infra/security/__tests__/rate-limiter.test.ts
## Gates
All pass: typecheck | lint | test:ci (103 files, 501 tests) | build | db:verify