### PR TITLE
Fix cockpit conversation thread interactions and outbound reply flow

### DIFF
--- a/src/app/api/cockpit/conversations/[id]/message/route.ts
+++ b/src/app/api/cockpit/conversations/[id]/message/route.ts
@@ -20,11 +20,13 @@ export async function POST(
     try {
         const { id: conversationId } = await context.params;
         const body = await request.json().catch(() => ({}));
-        const { message } = body;
+        const payloadText = typeof body?.text === 'string' ? body.text : body?.message;
 
-        if (!message || typeof message !== 'string' || message.trim() === '') {
-            return errorResponse('VALIDATION_ERROR' as any, 400, requestId, 'Message is required and cannot be empty');
+        if (!payloadText || typeof payloadText !== 'string' || payloadText.trim() === '') {
+            return errorResponse('VALIDATION_ERROR' as any, 400, requestId, 'Text is required and cannot be empty');
         }
+
+        const text = payloadText.trim();
 
         const conversation = await conversationService.getConversationById(tenantId, conversationId);
         if (!conversation) {
@@ -32,22 +34,26 @@ export async function POST(
         }
 
         const plaintextPhone = decryptString(conversation.phoneEncrypted);
-        
-        // 1. Send via Twilio
+
+        logger.info('cockpit.conversation.outbound_api_call', {
+            requestId,
+            tenantId,
+            conversationId,
+        });
+
         const sent = await twilioProvider.sendMessage(tenantId, {
             to: plaintextPhone,
-            body: message
+            body: text
         });
 
         if (!sent) {
             return errorResponse('TWILIO_API_ERROR' as any, 502, requestId, 'Failed to send message via Twilio');
         }
 
-        // 2. Persist to DB directly through service
         const conversationMessage = await conversationService.processOutboundMessage(
             tenantId,
             conversationId,
-            message,
+            text,
             'OPERATOR',
             conversation.customerId || undefined, // Emit timeline event to customer
             {
@@ -55,9 +61,16 @@ export async function POST(
             }
         );
 
+        logger.info('cockpit.conversation.outbound_success', {
+            requestId,
+            tenantId,
+            conversationId,
+            messageId: conversationMessage.id,
+        });
+
         return NextResponse.json({ ok: true, data: conversationMessage });
     } catch (err: any) {
-        logger.error('Failed to send operator message', err as Error, { requestId });
+        logger.error('Failed to send operator message', err as Error, { requestId, tenantId, operatorId });
         return errorResponse('INTERNAL_ERROR' as any, 500, requestId, err.message);
     }
 }

--- a/src/modules/conversas/components/conversation-actions.tsx
+++ b/src/modules/conversas/components/conversation-actions.tsx
@@ -6,15 +6,33 @@ import type { ConversationRecord } from '../types';
 export function ConversationActions({ conversation }: { conversation: ConversationRecord }) {
     return (
         <div className="flex flex-wrap items-center gap-3">
-            <Button variant="secondary" size="sm">
+            <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                    console.info('[cockpit] assumir agora click', { conversationId: conversation.id });
+                }}
+            >
                 <UserPlus className="h-4 w-4" />
                 Assumir agora
             </Button>
-            <Button variant="ghost" size="sm">
+            <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                    console.info('[cockpit] sugerir com ia click', { conversationId: conversation.id });
+                }}
+            >
                 <Bot className="h-4 w-4" />
                 Sugerir com IA
             </Button>
-            <Button variant="ghost" size="sm">
+            <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                    console.info('[cockpit] escalar click', { conversationId: conversation.id });
+                }}
+            >
                 <Flag className="h-4 w-4" />
                 Escalar
             </Button>

--- a/src/modules/conversas/components/conversation-thread.tsx
+++ b/src/modules/conversas/components/conversation-thread.tsx
@@ -8,12 +8,20 @@ import type { ConversationRecord } from '../types';
 export function ConversationThread({
     conversation,
     draft,
+    threadLoading,
+    sendingReply,
     onDraftChange,
+    onReply,
 }: {
     conversation: ConversationRecord;
     draft: string;
+    threadLoading: boolean;
+    sendingReply: boolean;
     onDraftChange: (value: string) => void;
+    onReply: () => Promise<void>;
 }) {
+    const isReplyDisabled = draft.trim().length === 0 || sendingReply;
+
     return (
         <SurfacePanel className="flex h-full min-h-[42rem] flex-col">
             <SectionHeader
@@ -31,9 +39,15 @@ export function ConversationThread({
             </div>
 
             <div className="mt-4 flex-1 space-y-3 overflow-y-auto rounded-[1.25rem] border border-[hsl(var(--ui-border))] bg-[hsl(var(--ui-page))] p-4">
-                {conversation.messages.map((message) => (
-                    <MessageBubble key={message.id} message={message} />
-                ))}
+                {threadLoading ? (
+                    <p className="text-sm text-[hsl(var(--ui-text-muted))]">Carregando mensagens...</p>
+                ) : conversation.messages.length === 0 ? (
+                    <p className="text-sm text-[hsl(var(--ui-text-muted))]">Nenhuma mensagem na thread.</p>
+                ) : (
+                    conversation.messages.map((message) => (
+                        <MessageBubble key={message.id} message={message} />
+                    ))
+                )}
             </div>
 
             <div className="mt-4 rounded-[1.25rem] border border-[hsl(var(--ui-border))] bg-[hsl(var(--ui-page))] p-4">
@@ -55,7 +69,9 @@ export function ConversationThread({
                     </p>
                     <div className="flex flex-wrap gap-2">
                         <Button variant="secondary" size="sm">Salvar rascunho</Button>
-                        <Button size="sm">Responder</Button>
+                        <Button size="sm" onClick={() => void onReply()} disabled={isReplyDisabled}>
+                            {sendingReply ? 'Enviando...' : 'Responder'}
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/src/modules/conversas/conversations-view.tsx
+++ b/src/modules/conversas/conversations-view.tsx
@@ -24,14 +24,21 @@ export function ConversationsView() {
         [querySignature, searchParams]
     );
 
-    const { conversations: allConversations, loading } = useConversations();
+    const {
+        conversations: allConversations,
+        loading,
+        threadLoading,
+        sendingReply,
+        selectedConversationId,
+        loadConversationThread,
+        sendReply,
+    } = useConversations();
 
     const ownerOptions = useMemo(
         () => Array.from(new Set(allConversations.map((c) => c.owner))),
         [allConversations]
     );
 
-    const [selectedConversationId, setSelectedConversationId] = useState('');
     const [searchValue, setSearchValue] = useState('');
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('todas');
     const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>('todas');
@@ -43,9 +50,9 @@ export function ConversationsView() {
     // Select first conversation once data loads
     useEffect(() => {
         if (allConversations.length > 0 && !selectedConversationId) {
-            setSelectedConversationId(allConversations[0].id);
+            void loadConversationThread(allConversations[0].id);
         }
-    }, [allConversations, selectedConversationId]);
+    }, [allConversations, loadConversationThread, selectedConversationId]);
 
     useEffect(() => {
         setSearchValue('');
@@ -113,7 +120,7 @@ export function ConversationsView() {
         });
 
         if (nextSelected?.id) {
-            setSelectedConversationId(nextSelected.id);
+            void loadConversationThread(nextSelected.id);
         }
     }, [
         allConversations,
@@ -124,6 +131,7 @@ export function ConversationsView() {
         routeContext.logisticsId,
         routeContext.priority,
         routeContext.status,
+        loadConversationThread,
     ]);
 
     const selectedConversation =
@@ -143,7 +151,7 @@ export function ConversationsView() {
 
     function handleSelectConversation(conversationId: string) {
         startTransition(() => {
-            setSelectedConversationId(conversationId);
+            void loadConversationThread(conversationId);
             setDraft('');
         });
     }
@@ -201,7 +209,19 @@ export function ConversationsView() {
                 />
                 {selectedConversation ? (
                     <>
-                        <ConversationThread conversation={selectedConversation} draft={draft} onDraftChange={setDraft} />
+                        <ConversationThread
+                            conversation={selectedConversation}
+                            draft={draft}
+                            threadLoading={threadLoading}
+                            sendingReply={sendingReply}
+                            onDraftChange={setDraft}
+                            onReply={async () => {
+                                const result = await sendReply(draft);
+                                if (result.ok) {
+                                    setDraft('');
+                                }
+                            }}
+                        />
                         <ConversationContext conversation={selectedConversation} />
                     </>
                 ) : null}

--- a/src/modules/conversas/use-conversations.ts
+++ b/src/modules/conversas/use-conversations.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
     ConversationChannel,
     ConversationContextData,
@@ -9,8 +9,6 @@ import type {
     ConversationRecord,
     ConversationStatus,
 } from './types';
-
-/* ── DB → UI status mapping ────────────────────────────────────────────────── */
 
 const STATUS_MAP: Record<string, ConversationStatus> = {
     OPEN: 'nova',
@@ -25,7 +23,11 @@ const CHANNEL_MAP: Record<string, ConversationChannel> = {
     PORTAL: 'Portal',
 };
 
-/* ── Helpers ────────────────────────────────────────────────────────────────── */
+const SOURCE_LABEL: Record<string, string> = {
+    WHATSAPP: 'Cliente',
+    OPERATOR: 'Operador',
+    SYSTEM: 'Sistema',
+};
 
 function relativeTime(isoOrNull: string | null | undefined): string {
     if (!isoOrNull) return '—';
@@ -36,6 +38,17 @@ function relativeTime(isoOrNull: string | null | undefined): string {
     const hours = Math.floor(mins / 60);
     if (hours < 24) return `${hours}h`;
     return `${Math.floor(hours / 24)}d`;
+}
+
+function formatTimestamp(isoOrNull: string | null | undefined): string {
+    if (!isoOrNull) return 'Agora';
+    const date = new Date(isoOrNull);
+    return new Intl.DateTimeFormat('pt-BR', {
+        hour: '2-digit',
+        minute: '2-digit',
+        day: '2-digit',
+        month: '2-digit',
+    }).format(date);
 }
 
 const emptyContext: ConversationContextData = {
@@ -49,8 +62,6 @@ const emptyContext: ConversationContextData = {
 };
 
 const emptyMessages: ConversationMessage[] = [];
-
-/* ── DB record shape (subset returned by the API) ──────────────────────────── */
 
 interface DbConversation {
     id: string;
@@ -67,7 +78,20 @@ interface DbConversation {
     updatedAt: string | null;
 }
 
-/* ── Transform ──────────────────────────────────────────────────────────────── */
+interface DbConversationMessage {
+    id: string;
+    direction: 'INBOUND' | 'OUTBOUND';
+    source: 'WHATSAPP' | 'OPERATOR' | 'SYSTEM';
+    message: string;
+    metadata: Record<string, unknown> | null;
+    createdAt: string;
+}
+
+interface ConversationDetailsResponse {
+    data?: {
+        messages?: DbConversationMessage[];
+    };
+}
 
 function toUiRecord(db: DbConversation): ConversationRecord {
     const status: ConversationStatus = STATUS_MAP[db.status] ?? 'nova';
@@ -95,12 +119,27 @@ function toUiRecord(db: DbConversation): ConversationRecord {
     };
 }
 
-/* ── Hook ────────────────────────────────────────────────────────────────────── */
+function toUiMessage(dbMessage: DbConversationMessage): ConversationMessage {
+    const actor = dbMessage.direction === 'OUTBOUND' ? 'humano' : 'cliente';
+    const author = SOURCE_LABEL[dbMessage.source] ?? 'Sistema';
+
+    return {
+        id: dbMessage.id,
+        actor,
+        author,
+        body: dbMessage.message,
+        timestamp: formatTimestamp(dbMessage.createdAt),
+        delivery: dbMessage.direction === 'OUTBOUND' ? 'enviado' : undefined,
+    };
+}
 
 export function useConversations() {
     const [conversations, setConversations] = useState<ConversationRecord[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [selectedConversationId, setSelectedConversationId] = useState<string>('');
+    const [threadLoading, setThreadLoading] = useState(false);
+    const [sendingReply, setSendingReply] = useState(false);
 
     const fetchConversations = useCallback(async () => {
         try {
@@ -115,7 +154,14 @@ export function useConversations() {
 
             const json = await res.json();
             const data: DbConversation[] = json.data ?? [];
-            setConversations(data.map(toUiRecord));
+            setConversations((current) => {
+                const currentById = new Map(current.map((conversation) => [conversation.id, conversation]));
+                return data.map((dbConversation) => {
+                    const mapped = toUiRecord(dbConversation);
+                    const existing = currentById.get(dbConversation.id);
+                    return existing ? { ...mapped, messages: existing.messages } : mapped;
+                });
+            });
             setError(null);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Erro desconhecido');
@@ -124,12 +170,115 @@ export function useConversations() {
         }
     }, []);
 
+    const loadConversationThread = useCallback(async (conversationId: string) => {
+        console.info('[cockpit] selectedConversationId', { conversationId });
+        setSelectedConversationId(conversationId);
+        try {
+            setThreadLoading(true);
+            const response = await fetch(`/api/cockpit/conversations/${conversationId}`);
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Erro ${response.status}: ${text}`);
+            }
+
+            const details = (await response.json()) as ConversationDetailsResponse;
+            const messages = (details.data?.messages ?? []).map(toUiMessage);
+
+            setConversations((current) => current.map((conversation) => (
+                conversation.id === conversationId
+                    ? {
+                        ...conversation,
+                        messages,
+                        lastMessage: messages[messages.length - 1]?.body ?? conversation.lastMessage,
+                    }
+                    : conversation
+            )));
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Falha ao carregar thread';
+            console.error('[cockpit] thread load failed', { conversationId, error: err });
+            setError(message);
+        } finally {
+            setThreadLoading(false);
+        }
+    }, []);
+
+    const selectedConversation = useMemo(
+        () => conversations.find((conversation) => conversation.id === selectedConversationId),
+        [conversations, selectedConversationId],
+    );
+
+    const sendReply = useCallback(async (text: string) => {
+        const trimmed = text.trim();
+
+        if (!selectedConversationId || trimmed.length === 0) {
+            return { ok: false as const, error: 'Conversa ou mensagem invalida.' };
+        }
+
+        console.info('[cockpit] composer submit', {
+            conversationId: selectedConversationId,
+            textLength: trimmed.length,
+        });
+
+        setSendingReply(true);
+        try {
+            const response = await fetch(`/api/cockpit/conversations/${selectedConversationId}/message`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: trimmed }),
+            });
+
+            console.info('[cockpit] outbound API call', {
+                conversationId: selectedConversationId,
+                status: response.status,
+            });
+
+            if (!response.ok) {
+                const textResponse = await response.text();
+                throw new Error(`Erro ${response.status}: ${textResponse}`);
+            }
+
+            await loadConversationThread(selectedConversationId);
+
+            console.info('[cockpit] outbound success', { conversationId: selectedConversationId });
+            return { ok: true as const };
+        } catch (err) {
+            console.error('[cockpit] outbound failed', { conversationId: selectedConversationId, error: err });
+            return {
+                ok: false as const,
+                error: err instanceof Error ? err.message : 'Falha ao enviar resposta',
+            };
+        } finally {
+            setSendingReply(false);
+        }
+    }, [loadConversationThread, selectedConversationId]);
+
     useEffect(() => {
         fetchConversations();
-        // Refresh every 30 seconds
         const interval = setInterval(fetchConversations, 30_000);
         return () => clearInterval(interval);
     }, [fetchConversations]);
 
-    return { conversations, loading, error, refetch: fetchConversations };
+    useEffect(() => {
+        if (!selectedConversationId) return;
+
+        const interval = setInterval(() => {
+            void loadConversationThread(selectedConversationId);
+        }, 5_000);
+
+        return () => clearInterval(interval);
+    }, [loadConversationThread, selectedConversationId]);
+
+    return {
+        conversations,
+        loading,
+        threadLoading,
+        sendingReply,
+        selectedConversationId,
+        selectedConversation,
+        error,
+        setSelectedConversationId,
+        loadConversationThread,
+        sendReply,
+        refetch: fetchConversations,
+    };
 }


### PR DESCRIPTION
### Motivation
- The thread UI rendered controls but lacked wiring: selecting a conversation did not load thread data and composer actions had no handlers. 
- Replies were not propagated to the backend or Twilio because the composer submit flow was not implemented end-to-end. 
- The goal was to enable selection → load thread → compose → send → persist → send via Twilio and keep the thread updated.

### Description
- Frontend: replaced list-only flow with an improved `useConversations` hook that tracks `selectedConversationId`, exposes `loadConversationThread`, `sendReply`, `threadLoading` and `sendingReply`, and maps DB messages into UI bubbles. (modified `src/modules/conversas/use-conversations.ts`)
- View wiring: `ConversationsView` now uses the new hook, calls `loadConversationThread` for initial selection / route-driven selection / click selection, and passes thread state + reply handler into the thread component. (modified `src/modules/conversas/conversations-view.tsx`)
- Composer & actions: `ConversationThread` gains `threadLoading`/`sendingReply`/`onReply` props, disables the reply button when empty or sending, shows loading/empty states, and clears the draft after successful send; `ConversationActions` buttons now have explicit click handlers (debug logs) so actions are clickable. (modified `src/modules/conversas/components/conversation-thread.tsx`, `src/modules/conversas/components/conversation-actions.tsx`)
- API & infra: outbound route `POST /api/cockpit/conversations/[id]/message` now accepts `{ text }` (backwards-compatible with `message`), trims/validates input, logs outbound attempts/success, calls `twilioProvider.sendMessage`, persists outbound via `conversationService.processOutboundMessage`, and returns the saved message. (modified `src/app/api/cockpit/conversations/[id]/message/route.ts`)
- Observability: added structured debug/info/error logs on selection, composer submit, outbound API call, success and failure across frontend and backend; multi-tenant isolation is preserved via `requireAdmin` and use of `tenantId` in API flows.

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npm run build` and Next.js compiled and built successfully. 
- Started dev and captured a local UI screenshot to verify thread loads, composer enables, and reply button triggers the client flow; full end-to-end WhatsApp delivery test was not executed here due to environment credentials (Twilio/tenant) and requires runtime tenant configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4df444a588331bf5680d6f6eceba3)