### PR TITLE
refactor(logistics): improve shipment module type safety and clarity

### DIFF
--- a/src/modules/logistics/__tests__/shipment.service.test.ts
+++ b/src/modules/logistics/__tests__/shipment.service.test.ts
@@ -88,7 +88,7 @@ describe('Shipment Logistics Service', () => {
     });
 
     it('should update tracking details and emit shipment_status_updated', async () => {
-        const mockShipment = { id: 'ship-1', orderId: 'order-1', status: 'CRETAED' };
+        const mockShipment = { id: 'ship-1', orderId: 'order-1', status: 'CREATED' };
         
         vi.mocked(shipmentRepository.updateShipment).mockResolvedValue();
         vi.mocked(shipmentRepository.findShipmentById).mockResolvedValue(mockShipment as any);

--- a/src/modules/logistics/index.ts
+++ b/src/modules/logistics/index.ts
@@ -1,1 +1,2 @@
 export type { ShipmentListFilter } from './shipment.repository';
+export type { ShipmentStatus } from './shipment.service';

--- a/src/modules/logistics/server.ts
+++ b/src/modules/logistics/server.ts
@@ -1,2 +1,3 @@
 export { shipmentService } from './shipment.service';
+export type { ShipmentStatus } from './shipment.service';
 export type { ShipmentListFilter } from './shipment.repository';

--- a/src/modules/logistics/shipment.service.ts
+++ b/src/modules/logistics/shipment.service.ts
@@ -1,9 +1,12 @@
 import { eq, and } from 'drizzle-orm';
 import { getDb } from '@/infra/db';
 import { orders, type ShipmentRecord } from '@/drizzle/schema';
-import { shipmentRepository, type ShipmentListFilter } from './shipment.repository';
+import { shipmentRepository } from './shipment.repository';
+import type { ShipmentListFilter } from './shipment.repository';
 import { shipmentEvents } from './shipment.events';
 import { ecosystemEventsService } from '@/services/ecosystem-events.service';
+
+export type ShipmentStatus = 'CREATED' | 'SCHEDULED' | 'PICKED_UP' | 'IN_TRANSIT' | 'OUT_FOR_DELIVERY' | 'DELIVERED' | 'FAILED';
 
 export const shipmentService = {
     async createShipmentFromOrder(tenantId: string, orderId: string): Promise<ShipmentRecord> {
@@ -64,11 +67,11 @@ export const shipmentService = {
     async updateShipmentStatus(
         tenantId: string,
         shipmentId: string,
-        status: 'CREATED' | 'SCHEDULED' | 'PICKED_UP' | 'IN_TRANSIT' | 'OUT_FOR_DELIVERY' | 'DELIVERED' | 'FAILED',
+        status: ShipmentStatus,
         trackingCode?: string,
         trackingUrl?: string
     ): Promise<void> {
-        const updateData: any = { status };
+        const updateData: { status: string; trackingCode?: string; trackingUrl?: string } = { status };
         if (trackingCode !== undefined) updateData.trackingCode = trackingCode;
         if (trackingUrl !== undefined) updateData.trackingUrl = trackingUrl;
 
@@ -106,6 +109,3 @@ export const shipmentService = {
         return shipmentRepository.listShipments(tenantId, filter);
     }
 };
-
-export type { ShipmentListFilter };
-


### PR DESCRIPTION
T1 — Extract ShipmentStatus named type:
  - Replaced inline 7-member union with exported ShipmentStatus type
  - Available via server.ts and index.ts entrypoints
  - Consumers no longer need to duplicate the union

T2 — Replace 'any' with proper type:
  - updateData in updateShipmentStatus typed as { status: string; trackingCode?: string; trackingUrl?: string }
  - Removed last 'any' from the module

T3 — Clean up re-exports:
  - Removed redundant ShipmentListFilter re-export from service (already exported by repository, index.ts, and server.ts)
  - Separated type import from value import for clarity

T4 — Fix test typo:
  - 'CRETAED' -> 'CREATED' in shipment.service.test.ts mock

Zero functional changes. Module is small and well-structured.

QG Results:
- typecheck: PASS
- lint:env: PASS
- lint:pii: PASS
- db:verify: PASS (no drift)
- routes:inventory: PASS (342 routes)
- routes:verify: PASS (342 routes)
- routes:verify-security: PASS (160 routes)
- test:ci: PASS (917 tests, 187 files)
- check:boundaries: PASS (1264 files)
- build: PASS
- release:check: RELEASE_CHECK_PASS
- npm audit: 0 vulnerabilities

## Description

<!-- Briefly describe the change. -->

## Checklist

- [ ] All local gates pass (`tools/gates/gates.ps1` or `tools/gates/gates.sh`)
- [ ] New routes are registered in `docs/routes-registry.md`
- [ ] `docs/surface-map.md` is updated if surface classification changed
- [ ] No auth changes were made without corresponding tests
- [ ] No secrets are hardcoded in code, YAML, or logs
- [ ] PII is not exposed in logs, events, or public API responses
- [ ] `npm run routes:verify` passes

## Related Issues / PRs

<!-- Link related issues or PRs here. -->
