### PR TITLE
refactor(crm): add entrypoints, deduplicate query, redirect imports

### DIFF
--- a/src/modules/atendimento/freight-quote.service.ts
+++ b/src/modules/atendimento/freight-quote.service.ts
@@ -5,7 +5,7 @@ import { domineIntakeService } from '@/domine/domine-intake.service';
 import { eq, and, desc } from 'drizzle-orm';
 import { logger } from '@/infra/logger';
 import crypto from 'crypto';
-import { crmService } from '@/modules/crm/crm.service';
+import { crmService } from '@/modules/crm/server';
 
 export interface CreateFreightQuoteInput {
     tenantId: string;

--- a/src/modules/atendimento/message.service.ts
+++ b/src/modules/atendimento/message.service.ts
@@ -19,7 +19,7 @@ import { conversationMessages, conversations } from '@/drizzle/schema';
 import { operationalEvents } from '@/drizzle/schema';
 import { randomUUID } from 'crypto';
 import type { ConversationMessageRecord } from '@/drizzle/schema';
-import { crmService } from '@/modules/crm/crm.service';
+import { crmService } from '@/modules/crm/server';
 import { ecosystemEventsService } from '@/services/ecosystem-events.service';
 
 export const messageService = {

--- a/src/modules/crm/crm.service.ts
+++ b/src/modules/crm/crm.service.ts
@@ -6,6 +6,24 @@ import { randomUUID } from 'crypto';
 import { ecosystemEventsService } from '@/services/ecosystem-events.service';
 import { operationalAuditService } from '@/modules/audit/operational-audit.service';
 
+// ── Internal helper ────────────────────────────────────────────────────────
+
+async function findActiveOpportunity(db: any, tenantId: string, customerId: string) {
+    const results = await db.select()
+        .from(crmOpportunities)
+        .where(
+            and(
+                eq(crmOpportunities.tenantId, tenantId),
+                eq(crmOpportunities.customerId, customerId),
+                eq(crmOpportunities.status, 'active')
+            )
+        )
+        .limit(1);
+    return results[0] ?? null;
+}
+
+// ── Public service ─────────────────────────────────────────────────────────
+
 export const crmService = {
     /**
      * Projects a WhatsApp Interaction into the CRM Pipeline.
@@ -30,23 +48,13 @@ export const crmService = {
         const db = tx || await getDb();
 
         try {
-            // Find active opportunity
-            const activeOps = await db.select()
-                .from(crmOpportunities)
-                .where(
-                    and(
-                        eq(crmOpportunities.tenantId, params.tenantId),
-                        eq(crmOpportunities.customerId, params.customerId),
-                        eq(crmOpportunities.status, 'active')
-                    )
-                )
-                .limit(1);
+            const activeOp = await findActiveOpportunity(db, params.tenantId, params.customerId);
 
-            if (activeOps.length > 0) {
+            if (activeOp) {
                 // Update last activity
                 await db.update(crmOpportunities)
                     .set({ lastActivityAt: new Date() })
-                    .where(eq(crmOpportunities.id, activeOps[0].id));
+                    .where(eq(crmOpportunities.id, activeOp.id));
             } else if (params.direction === 'inbound') {
                 // Create new opportunity if inbound message and no active ops
                 const title = `Negociação Automática`;
@@ -120,22 +128,12 @@ export const crmService = {
         const db = tx || await getDb();
 
         try {
-            // Find active opportunity
-            const activeOps = await db.select()
-                .from(crmOpportunities)
-                .where(
-                    and(
-                        eq(crmOpportunities.tenantId, params.tenantId),
-                        eq(crmOpportunities.customerId, params.customerId),
-                        eq(crmOpportunities.status, 'active')
-                    )
-                )
-                .limit(1);
+            const activeOp = await findActiveOpportunity(db, params.tenantId, params.customerId);
 
             let opportunityId;
 
-            if (activeOps.length > 0) {
-                opportunityId = activeOps[0].id;
+            if (activeOp) {
+                opportunityId = activeOp.id;
                 // Update stage to quoted if not already won/lost
                 await db.update(crmOpportunities)
                     .set({ stage: 'quoted', lastActivityAt: new Date() })

--- a/src/modules/crm/index.ts
+++ b/src/modules/crm/index.ts
@@ -1,0 +1,1 @@
+// CRM module — client-safe exports (types only, no server code)

--- a/src/modules/crm/server.ts
+++ b/src/modules/crm/server.ts
@@ -1,0 +1,1 @@
+export { crmService } from './crm.service';

--- a/src/modules/frank/frank.service.ts
+++ b/src/modules/frank/frank.service.ts
@@ -4,7 +4,7 @@ import { eq, and } from 'drizzle-orm';
 import { crmTasks, simulations, conversations } from '@/drizzle/schema';
 import { frankContextBuilder } from './frank.context-builder';
 import { randomUUID } from 'crypto';
-import { crmService } from '@/modules/crm/crm.service';
+import { crmService } from '@/modules/crm/server';
 import { frankSuggestions } from './frank.suggestions';
 import { FrankOperationalDraft } from './frank.schema';
 


### PR DESCRIPTION
T1 — Create module entrypoints:
  - Added server.ts (exports crmService)
  - Added index.ts (comment-only, no client exports yet)
  - CRM now follows the same module boundary pattern as all other modules

T2 — Redirect consumers to entrypoint:
  - frank/frank.service.ts: crm/crm.service -> crm/server
  - atendimento/freight-quote.service.ts: crm/crm.service -> crm/server
  - atendimento/message.service.ts: crm/crm.service -> crm/server

T3 — Extract findActiveOpportunity helper:
  - Deduplicated the 'find active opportunity by tenant+customer' query that was identically repeated in projectMessageActivity and syncSimulationToQuote (10 lines each)
  - Single private helper, same query, same behavior

Zero functional changes. No schema changes. No business logic changes.

QG Results:
- typecheck: PASS
- lint:env: PASS
- lint:pii: PASS
- db:verify: PASS (no drift)
- routes:inventory: PASS (342 routes)
- routes:verify: PASS (342 routes)
- routes:verify-security: PASS (160 routes)
- test:ci: PASS (917 tests, 187 files)
- check:boundaries: PASS (1266 files)
- build: PASS
- release:check: RELEASE_CHECK_PASS
- npm audit: 0 vulnerabilities

## Description

<!-- Briefly describe the change. -->

## Checklist

- [ ] All local gates pass (`tools/gates/gates.ps1` or `tools/gates/gates.sh`)
- [ ] New routes are registered in `docs/routes-registry.md`
- [ ] `docs/surface-map.md` is updated if surface classification changed
- [ ] No auth changes were made without corresponding tests
- [ ] No secrets are hardcoded in code, YAML, or logs
- [ ] PII is not exposed in logs, events, or public API responses
- [ ] `npm run routes:verify` passes

## Related Issues / PRs

<!-- Link related issues or PRs here. -->
