### PR TITLE
refactor(orders,freight): create server entrypoints, reduce allowlist…

### DIFF
--- a/scripts/check-import-boundaries.ts
+++ b/scripts/check-import-boundaries.ts
@@ -45,30 +45,11 @@ const KNOWN_DEEP_IMPORTS_RE = /from\s+['"]@\/modules\/([^'"\/]+)\/(cache-keys)['
 // Files that are known to have deep imports that require refactor (tracked debt).
 // Each entry MUST have a TODO(boundary) comment explaining the reason and removal path.
 const ALLOWLIST: string[] = [
-  // ── frank tools → pedidos/freight repositories ─────────────────────────
-  // TODO(boundary): frank tools import pedidos/freight repositories directly.
-  // Removal: create @/modules/pedidos/server and @/modules/freight/server entrypoints.
-  'src/modules/frank/tools/read-only/getRecentQuotes.tool.ts',
-  'src/modules/frank/tools/read-only/getRecentOrders.tool.ts',
-  'src/modules/frank/tools/read-only/getOrderStatus.tool.ts',
-  'src/modules/frank/tools/read-only/getShipmentStatus.tool.ts',
-
-  // ── atendimento → pedidos internals ────────────────────────────────────
-  // TODO(boundary): atendimento orchestrator imports pedidos services/ directory.
-  // Removal: create @/modules/pedidos/server entrypoint and re-export needed services.
-  'src/modules/atendimento/whatsapp-inbound-orchestrator.service.ts',
-
   // ── test files (vi.mock paths match regex but are not runtime imports) ─
   // TODO(boundary): vi.mock() paths in test files match the regex pattern.
   // These are not actual runtime imports. Consider excluding __tests__/ from enforcement.
   'src/app/api/webhook/stripe/__tests__/stripe-lifecycle.test.ts',
   'src/app/api/webhook/stripe/__tests__/stripe-gates.test.ts',
-
-  // ── app routes → module internals ──────────────────────────────────────
-  // TODO(boundary): routes import module adapters/ directories directly.
-  // Removal: create @/modules/freight/server entrypoint for adapter exports.
-  'src/app/api/freight/shipments/route.ts',
-  'src/app/api/internal/freight/shipments/route.ts',
 
   // ── UI components cross-module ─────────────────────────────────────────
   // TODO(boundary): UI pages/views import React components from other modules.

--- a/src/app/api/freight/shipments/route.ts
+++ b/src/app/api/freight/shipments/route.ts
@@ -5,7 +5,7 @@ import { freightShipments, freightConfirmations } from '@/drizzle/schema';
 import { eq, desc } from 'drizzle-orm';
 import { ErrorCode, errorResponse } from '@/infra/http/error-response';
 import { makeRequestId } from '@/infra/http/request-trace';
-import { createShipmentFromQuote, CreateShipmentInput } from '@/modules/freight/adapters/melhor-envio-shipment';
+import { createShipmentFromQuote, type CreateShipmentInput } from '@/modules/freight/server';
 
 export const dynamic = 'force-dynamic';
 

--- a/src/app/api/internal/freight/shipments/route.ts
+++ b/src/app/api/internal/freight/shipments/route.ts
@@ -12,7 +12,7 @@ import { freightShipments } from '@/drizzle/schema';
 import { eq, desc } from 'drizzle-orm';
 import { ErrorCode, errorResponse } from '@/infra/http/error-response';
 import { makeRequestId } from '@/infra/http/request-trace';
-import { createShipmentFromQuote, CreateShipmentInput } from '@/modules/freight/adapters/melhor-envio-shipment';
+import { createShipmentFromQuote, type CreateShipmentInput } from '@/modules/freight/server';
 
 export const dynamic = 'force-dynamic';
 

--- a/src/modules/atendimento/whatsapp-inbound-orchestrator.service.ts
+++ b/src/modules/atendimento/whatsapp-inbound-orchestrator.service.ts
@@ -17,7 +17,7 @@ import { resolveConversationMode, isEntitiesCompleteForIntent } from '@/modules/
 import { evaluateAutoResponseGuard } from '@/modules/frank/auto-response-guard';
 import { messageService } from '@/modules/atendimento/message.service';
 import { suggestionService } from '@/modules/frank/suggestions/suggestion.service';
-import { findOrderWithShipmentByPrefix } from '@/modules/pedidos/order.repository';
+import { findOrderWithShipmentByPrefix } from '@/modules/pedidos/server';
 import { structuredLogger } from '@/infra/log/logger';
 import { logger } from '@/infra/logger';
 import { resolveInboundReplyPolicy, InboundReplyPolicy } from './whatsapp-reply-policy';

--- a/src/modules/frank/tools/read-only/getOrderStatus.tool.ts
+++ b/src/modules/frank/tools/read-only/getOrderStatus.tool.ts
@@ -1,5 +1,5 @@
-import { getOrderAggregate } from '@/modules/pedidos/order.repository';
-import { getShipmentsForOrder } from '@/modules/freight/shipment-linkage.repository';
+import { getOrderAggregate } from '@/modules/pedidos/server';
+import { getShipmentsForOrder } from '@/modules/freight/server';
 import { executeFrankTool } from '../tool-guard';
 import { selectLatestShipment, toShipmentSummary, type ShipmentSummary } from './shared';
 

--- a/src/modules/frank/tools/read-only/getRecentOrders.tool.ts
+++ b/src/modules/frank/tools/read-only/getRecentOrders.tool.ts
@@ -1,5 +1,5 @@
-import { getRecentOrdersForCustomer } from '@/modules/pedidos/order.repository';
-import { getShipmentsForOrder } from '@/modules/freight/shipment-linkage.repository';
+import { getRecentOrdersForCustomer } from '@/modules/pedidos/server';
+import { getShipmentsForOrder } from '@/modules/freight/server';
 import { executeFrankTool } from '../tool-guard';
 import { clampSupportLimit, selectLatestShipment, toShipmentSummary, type ShipmentSummary } from './shared';
 

--- a/src/modules/frank/tools/read-only/getRecentQuotes.tool.ts
+++ b/src/modules/frank/tools/read-only/getRecentQuotes.tool.ts
@@ -1,5 +1,5 @@
-import { getRecentOrdersForCustomer } from '@/modules/pedidos/order.repository';
-import { getQuoteContext } from '@/modules/freight/quote-context.repository';
+import { getRecentOrdersForCustomer } from '@/modules/pedidos/server';
+import { getQuoteContext } from '@/modules/freight/server';
 import { executeFrankTool } from '../tool-guard';
 import { buildQuoteRouteSummary, clampSupportLimit } from './shared';
 

--- a/src/modules/frank/tools/read-only/getShipmentStatus.tool.ts
+++ b/src/modules/frank/tools/read-only/getShipmentStatus.tool.ts
@@ -1,5 +1,5 @@
 import { deliveriesRepository } from '@/infra/repositories/deliveries.repository';
-import { getShipmentById } from '@/modules/freight/shipment-linkage.repository';
+import { getShipmentById } from '@/modules/freight/server';
 import { executeFrankTool } from '../tool-guard';
 
 export interface ShipmentLocationEventSummary {

--- a/src/modules/freight/server.ts
+++ b/src/modules/freight/server.ts
@@ -1,0 +1,14 @@
+/**
+ * Freight Module — Server Entrypoint.
+ *
+ * Re-exports server-only symbols for consumers outside the freight module.
+ * Use `@/modules/freight/server` to import these.
+ */
+
+// ── Repository exports for cross-module consumers ────────────────────
+export { getQuoteContext } from './quote-context.repository';
+export { getShipmentsForOrder, getShipmentById } from './shipment-linkage.repository';
+
+// ── Adapter exports for app routes ───────────────────────────────────
+export { createShipmentFromQuote } from './adapters/melhor-envio-shipment';
+export type { CreateShipmentInput } from './adapters/melhor-envio-shipment';

--- a/src/modules/pedidos/server.ts
+++ b/src/modules/pedidos/server.ts
@@ -1,2 +1,9 @@
 export { loadOrdersHydrated } from './order.loader';
 export { createOrderFromSimulation } from './order.service';
+
+// ── Read-only repository exports for cross-module consumers ──────────
+export {
+    getRecentOrdersForCustomer,
+    getOrderAggregate,
+    findOrderWithShipmentByPrefix,
+} from './order.repository';


### PR DESCRIPTION
… by 7

Server entrypoints created/extended:
- src/modules/pedidos/server.ts — added: getRecentOrdersForCustomer, getOrderAggregate, findOrderWithShipmentByPrefix (from order.repository)
- src/modules/freight/server.ts — new file, exports: getQuoteContext (quote-context.repository), getShipmentsForOrder, getShipmentById (shipment-linkage.repository), createShipmentFromQuote, CreateShipmentInput (adapters/melhor-envio-shipment)

Consumers redirected (8 files):
- 4 frank tools → @/modules/pedidos/server + @/modules/freight/server (was pedidos/order.repository + freight/*.repository)
- 1 atendimento → @/modules/pedidos/server (was pedidos/order.repository)
- 2 freight routes → @/modules/freight/server (was freight/adapters/melhor-envio-shipment)

Allowlist reduced: 15 → 8 entries (removed 7):
- 4 frank tools
- 1 atendimento orchestrator
- 2 freight shipment routes

Remaining 8 entries (tracked debt):
- 2 test files (vi.mock patterns, not runtime imports)
- 6 UI cross-module (pending separate PR)

Zero functional changes.

QG: all 12 passed, RELEASE_CHECK_PASS

## Description

<!-- Briefly describe the change. -->

## Checklist

- [ ] All local gates pass (`tools/gates/gates.ps1` or `tools/gates/gates.sh`)
- [ ] New routes are registered in `docs/routes-registry.md`
- [ ] `docs/surface-map.md` is updated if surface classification changed
- [ ] No auth changes were made without corresponding tests
- [ ] No secrets are hardcoded in code, YAML, or logs
- [ ] PII is not exposed in logs, events, or public API responses
- [ ] `npm run routes:verify` passes

## Related Issues / PRs

<!-- Link related issues or PRs here. -->
