### PR TITLE
Add canonical `/pricing` redirect to `/planos/envios`, tests and route registry update

### DIFF
--- a/docs/_generated/routes-inventory.md
+++ b/docs/_generated/routes-inventory.md
@@ -325,6 +325,7 @@
 | `/planos/envios` | Page |
 | `/plataforma` | Page |
 | `/plataforma/cockpit` | Page |
+| `/pricing` | Page |
 | `/privacidade` | Page |
 | `/produtos/crm` | Page |
 | `/produtos/domine` | Page |

--- a/docs/routes-registry.md
+++ b/docs/routes-registry.md
@@ -274,6 +274,7 @@
 | /inbox/conversations/[id] | TBA | public | none | PUBLIC | live | Auto-detected |
 | /login | TBA | public | none | PUBLIC | live | Auto-detected |
 | /painel-logistico | TBA | public | none | PUBLIC | live | Auto-detected |
+| /pricing | Pricing redirect | public | none | PUBLIC | live | Canonical redirect to /planos/envios preserving query string |
 | /planos/crm | TBA | public | none | PUBLIC | live | Auto-detected |
 | /planos/domine | TBA | public | none | PUBLIC | live | Auto-detected |
 | /planos/envios | TBA | public | none | PUBLIC | live | Auto-detected |

--- a/src/app/pricing/__tests__/route.test.ts
+++ b/src/app/pricing/__tests__/route.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, HEAD } from '../route';
+import { structuredLogger } from '@/infra/log/logger';
+
+vi.mock('@/infra/log/logger', () => ({
+  structuredLogger: {
+    info: vi.fn(),
+  },
+}));
+
+describe('GET /pricing', () => {
+  it('redirects to /planos/envios preserving the query string', async () => {
+    const request = new NextRequest('http://localhost/pricing?canceled=1&utm_source=google');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/planos/envios?canceled=1&utm_source=google');
+    expect(structuredLogger.info).toHaveBeenCalledWith('public_pricing_redirect', expect.objectContaining({
+      route: '/pricing',
+      destination: '/planos/envios',
+      hasQuery: true,
+    }));
+  });
+
+  it('reuses the same redirect behavior for HEAD requests', async () => {
+    const request = new NextRequest('http://localhost/pricing');
+
+    const response = await HEAD(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/planos/envios');
+  });
+});

--- a/src/app/pricing/route.ts
+++ b/src/app/pricing/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { structuredLogger } from '@/infra/log/logger';
+
+const PRICING_DESTINATION_PATH = '/planos/envios';
+
+function buildPricingRedirectUrl(request: NextRequest): URL {
+  const redirectUrl = request.nextUrl.clone();
+  redirectUrl.pathname = PRICING_DESTINATION_PATH;
+  return redirectUrl;
+}
+
+export async function GET(request: NextRequest) {
+  const redirectUrl = buildPricingRedirectUrl(request);
+
+  structuredLogger.info('public_pricing_redirect', {
+    route: request.nextUrl.pathname,
+    eventType: 'public_navigation',
+    destination: redirectUrl.pathname,
+    hasQuery: Boolean(request.nextUrl.search),
+  });
+
+  return NextResponse.redirect(redirectUrl, { status: 307 });
+}
+
+export async function HEAD(request: NextRequest) {
+  return GET(request);
+}


### PR DESCRIPTION
### Motivation
- The QA visual gate and route guardrails referenced `/pricing` but the project lacked a concrete `/pricing` route, causing CI/QA failures during snapshot validation and route verification. 
- Multiple places in the codebase (sitemap, robots, checkout cancel URL, CTAs) expect `/pricing` to exist as a public entrypoint.

### Description
- Add a canonical redirect route at `src/app/pricing/route.ts` that returns a `307` redirect to `/planos/envios` while preserving the query string and emitting a structured log via `structuredLogger`.
- Add unit tests at `src/app/pricing/__tests__/route.test.ts` covering `GET` and `HEAD` behavior and asserting the redirect target, query preservation and logging call.
- Update route documentation/guardrails: add `/pricing` entry to `docs/routes-registry.md` and refresh the generated inventory (`docs/_generated/routes-inventory.md`) so `routes:sync`/guardrails pass.

### Testing
- Ran `npx vitest run --configLoader runner --config vitest.config.mjs src/app/pricing/__tests__/route.test.ts` and the tests passed.
- Ran `npm run routes:sync` (inventory + verify) and the route registry verification passed after adding the `/pricing` entry.
- Ran `npm run typecheck` (`tsc -p tsconfig.build.json --noEmit`) and type checking completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba175f1010833194108e255895ea3c)