### PR TITLE
Introduce purpose-specific internal tokens and enforce strict runtime internal auth contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,38 @@ npm run test:ci
 | `AUTH_SECRET` | JWT session signing |
 | `PII_ENCRYPTION_KEY` | AES-256-GCM key for PII encryption |
 | `REDIS_URL` | Cache, rate limiting, session support |
-| `INTERNAL_DIAG_TOKEN` | Internal API authentication |
+| `INTERNAL_DIAG_TOKEN` | Official token for diagnostics/health endpoints |
+| `INTERNAL_EXPORT_TOKEN` | Official token for export/read-only internal flows |
+| `INTERNAL_JOB_TOKEN` | Official token for jobs/cron/internal workers |
+| `INTERNAL_TOKEN` | Legacy alias accepted only for `jobs` routes |
+| `QA_BOOTSTRAP_TOKEN` | QA bootstrap token for `/api/internal/qa/*` |
+| `BOOTSTRAP_TOKEN` | Extra bootstrap header required only by guarded bootstrap flows |
 | `TWILIO_AUTH_TOKEN` | WhatsApp webhook signature verification |
 | `STRIPE_SECRET_KEY` | Payment webhook verification |
 | `MELHORENVIO_TOKEN` | Freight API integration |
+
+
+### Internal Auth Contract
+
+> Este contrato centralizado cobre **tokens internos por propósito**. Ele não redefine toda a política global de config/auth do sistema.
+
+**Official env names**
+- `INTERNAL_DIAG_TOKEN` → propósito `diag`.
+- `INTERNAL_EXPORT_TOKEN` → propósito `export`.
+- `INTERNAL_JOB_TOKEN` → propósito `jobs`.
+- `QA_BOOTSTRAP_TOKEN` → propósito `qa_bootstrap` para `/api/internal/qa/*`.
+- `BOOTSTRAP_TOKEN` → segundo fator adicional apenas para fluxos que chamam `requireInternalAuth(..., { requireBootstrapToken: true })`.
+
+**Legacy aliases**
+- `INTERNAL_TOKEN` é legado e continua aceito somente para propósito `jobs`.
+- Header `x-qa-bootstrap` continua aceito como alias legado de `x-qa-token`.
+
+**Usage rules by purpose**
+- Middleware e guards compartilham o mesmo contrato: `x-internal-token`/`?token=` para `diag`, `export` e `jobs`; `x-qa-token` (ou alias legado `x-qa-bootstrap`) para `qa_bootstrap`.
+- Em runtimes strict (`NODE_ENV=production`, `VERCEL_ENV=preview|production` ou `APP_ENV=staging`), a aplicação falha cedo se `INTERNAL_DIAG_TOKEN`, `INTERNAL_EXPORT_TOKEN` ou `INTERNAL_JOB_TOKEN` não estiverem configurados.
+- Em desenvolvimento, o fallback efêmero continua restrito ao par `diag/export` e não mascara o comportamento de staging/produção.
+- `/api/internal/*` permanece fail-closed sem token mesmo em desenvolvimento; o que continua flexível em dev é apenas o fallback efêmero usado por fluxos server-side de `diag/export`.
+- A política atual de `AUTH_SECRET` não mudou nesta PR: ele continua obrigatório em runtimes strict, enquanto o fallback local de `src/infra/auth/session.ts` segue preservado fora deles.
 
 ## Deployment
 

--- a/docs/architecture/app-structure.md
+++ b/docs/architecture/app-structure.md
@@ -104,7 +104,7 @@ As API routes seguem 5 padrões de autenticação e escopo:
 |---|---|---|---|
 | **Public** | `/api/public/*` | Nenhuma | `/api/public/cotacao/quotes`, `/api/public/events` |
 | **Cockpit** | `/api/cockpit/*` | Session cookie (any role) | `/api/cockpit/metrics`, `/api/cockpit/analytics/*` |
-| **Internal** | `/api/internal/*` | Internal token (`INTERNAL_API_TOKEN`) | `/api/internal/diag`, `/api/internal/jobs/*` |
+| **Internal** | `/api/internal/*` | Internal tokens por propósito (`INTERNAL_DIAG_TOKEN`, `INTERNAL_EXPORT_TOKEN`, `INTERNAL_JOB_TOKEN`) | `/api/internal/diag`, `/api/internal/jobs/*` |
 | **Tenant-scoped** | `/api/tenants/[tenantId]/*` | Session cookie + tenant match | `/api/tenants/[tenantId]/settings`, `/api/tenants/[tenantId]/domine/*` |
 | **Webhook** | `/api/webhook/*` | Signature verification | `/api/webhook/stripe` (Stripe sig), `/api/whatsapp/*` (Twilio sig) |
 

--- a/docs/architecture/implementation-rules.md
+++ b/docs/architecture/implementation-rules.md
@@ -196,7 +196,7 @@ await emitEvent({
 
 1. `AUTH_SECRET`: Chave HS256 para JWT. Em produção, obrigatório — boot falha sem ela
 2. `PII_ENCRYPTION_KEY`: Chave AES-256-GCM. Em produção, obrigatório
-3. `INTERNAL_API_TOKEN`: Token para rotas internal. Validação fail-closed
+3. `INTERNAL_DIAG_TOKEN` / `INTERNAL_EXPORT_TOKEN` / `INTERNAL_JOB_TOKEN`: tokens oficiais por propósito para rotas internal. `INTERNAL_TOKEN` é apenas alias legado para jobs. Validação fail-closed
 4. Secrets nunca logados — logger auto-redact
 
 ### Rate Limiting

--- a/src/__tests__/internal-auth-contract.test.ts
+++ b/src/__tests__/internal-auth-contract.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { requireInternalToken } from '@/infra/auth/tenant-route-guard';
+import { assertCriticalEnvSetup } from '@/infra/env/require-env';
+
+function makeRequest(url: string, headers: Record<string, string> = {}) {
+  return new NextRequest(url, { headers: new Headers(headers) });
+}
+
+describe('internal auth contract', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    process.env = { ...process.env };
+    delete process.env.INTERNAL_DIAG_TOKEN;
+    delete process.env.INTERNAL_EXPORT_TOKEN;
+    delete process.env.INTERNAL_JOB_TOKEN;
+    delete process.env.INTERNAL_TOKEN;
+    delete process.env.QA_BOOTSTRAP_TOKEN;
+    delete process.env.BOOTSTRAP_TOKEN;
+    delete process.env.CI;
+    process.env.NODE_ENV = 'test';
+    process.env.AUTH_SECRET = 'test-secret-at-least-16-chars';
+    process.env.DATABASE_URL = 'mysql://user:pass@localhost:3306/db';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+  });
+
+  it('authorizes a valid diag token for diag routes', () => {
+    process.env.INTERNAL_DIAG_TOKEN = 'diag-secret';
+
+    const result = requireInternalToken(
+      makeRequest('http://localhost/api/internal/diag', { 'x-internal-token': 'diag-secret' }),
+      { purpose: ['diag'] },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an invalid token', () => {
+    process.env.INTERNAL_EXPORT_TOKEN = 'export-secret';
+
+    const result = requireInternalToken(
+      makeRequest('http://localhost/api/internal/export', { 'x-internal-token': 'wrong-secret' }),
+      { purpose: ['export'] },
+    );
+
+    expect(result.ok).toBe(false);
+    expect((result as any).response.status).toBe(401);
+  });
+
+  it('rejects a valid token when the purpose is wrong', () => {
+    process.env.INTERNAL_DIAG_TOKEN = 'diag-secret';
+
+    const result = requireInternalToken(
+      makeRequest('http://localhost/api/internal/jobs/run', { 'x-internal-token': 'diag-secret' }),
+      { purpose: ['jobs'] },
+    );
+
+    expect(result.ok).toBe(false);
+    expect((result as any).response.status).toBe(401);
+  });
+
+  it('keeps explicit legacy compatibility for INTERNAL_TOKEN on jobs routes', () => {
+    process.env.INTERNAL_TOKEN = 'legacy-job-secret';
+
+    const result = requireInternalToken(
+      makeRequest('http://localhost/api/internal/jobs/run', { 'x-internal-token': 'legacy-job-secret' }),
+      { purpose: ['jobs'] },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('keeps explicit legacy header compatibility for QA bootstrap', () => {
+    process.env.QA_BOOTSTRAP_TOKEN = 'qa-secret';
+
+    const result = requireInternalToken(
+      makeRequest('http://localhost/api/internal/qa/setup', { 'x-qa-bootstrap': 'qa-secret' }),
+      { purpose: ['qa_bootstrap'] },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+
+  it('keeps local/dev boot coherent with session AUTH_SECRET fallback', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.AUTH_SECRET;
+
+    expect(() => assertCriticalEnvSetup()).not.toThrow();
+  });
+
+  it('still requires AUTH_SECRET in strict runtimes', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.VERCEL_ENV = 'production';
+    process.env.INTERNAL_DIAG_TOKEN = 'diag-secret';
+    process.env.INTERNAL_EXPORT_TOKEN = 'export-secret';
+    process.env.INTERNAL_JOB_TOKEN = 'job-secret';
+    delete process.env.AUTH_SECRET;
+
+    expect(() => assertCriticalEnvSetup()).toThrow(/AUTH_SECRET/);
+  });
+
+  it('fails early in strict runtime when critical internal tokens are missing', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.VERCEL_ENV = 'preview';
+
+    expect(() => assertCriticalEnvSetup()).toThrow(
+      /INTERNAL_DIAG_TOKEN, INTERNAL_EXPORT_TOKEN, INTERNAL_JOB_TOKEN/,
+    );
+  });
+});

--- a/src/app/api/internal/billing/__tests__/reconcile-stripe.test.ts
+++ b/src/app/api/internal/billing/__tests__/reconcile-stripe.test.ts
@@ -62,11 +62,6 @@ vi.mock('../../../../../infra/http/request-trace', () => ({
     attachRequestIdHeader: vi.fn((res: any) => res),
 }));
 
-vi.mock('../../../../../infra/config/internal-token', () => ({
-    isInternalTokenAuthorized: vi.fn((token: string) => token === 'valid-token'),
-    getInternalExportTokenOrThrow: vi.fn(() => 'valid-token'),
-}));
-
 vi.mock('../../../../../core/stripe/stripe-client', () => ({
     getStripe: vi.fn(() => ({
         subscriptions: {
@@ -127,6 +122,7 @@ describe('POST /api/internal/billing/reconcile-stripe', () => {
         _mockDbRows = [];
         _updateCapture.length = 0;
         _mockStripeSubResponse = {};
+        process.env.INTERNAL_JOB_TOKEN = 'valid-token';
         vi.mocked(getDb).mockImplementation(() => Promise.resolve(makeMockDb() as any));
     });
 

--- a/src/core/ai/__tests__/llm-gateway.test.ts
+++ b/src/core/ai/__tests__/llm-gateway.test.ts
@@ -106,7 +106,7 @@ describe('llm-gateway', () => {
         timeoutMs: 15000,
       })
     );
-  });
+  }, 40000);
 
   it('uses tenant-specific config when available', async () => {
     mockGetProviderConfig.mockResolvedValueOnce({
@@ -129,7 +129,7 @@ describe('llm-gateway', () => {
         timeoutMs: 25000,
       })
     );
-  });
+  }, 20000);
 
   it('blocks chat when rate limit is exceeded', async () => {
     mockCheckRateLimit.mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt: Date.now() + 60000 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,21 +2,28 @@ import { z } from "zod";
 
 const EnvSchema = z.object({
   NODE_ENV: z.string().optional(),
+  VERCEL_ENV: z.string().optional(),
+  APP_ENV: z.string().optional(),
   AUTH_SECRET: z.string().min(16),
   DATABASE_URL: z.string().min(10),
   SEED_TOKEN: z.string().min(8),
   ADMIN_SEED_PASSWORD: z.string().min(8).optional(),
   REDIS_URL: z.string().min(10).optional(),
   GITHUB_TOKEN: z.string().min(10).optional(),
+  INTERNAL_DIAG_TOKEN: z.string().min(8).optional(),
+  INTERNAL_EXPORT_TOKEN: z.string().min(8).optional(),
+  INTERNAL_JOB_TOKEN: z.string().min(8).optional(),
+  INTERNAL_TOKEN: z.string().min(8).optional(),
+  QA_BOOTSTRAP_TOKEN: z.string().min(8).optional(),
+  BOOTSTRAP_TOKEN: z.string().min(8).optional(),
   // 64 chars hex = 32 bytes para AES-256-GCM. Obrigatório em prod via boot-check.
   PROVIDER_SECRETS_KEY: z.string().length(64).optional(),
 });
 
 export const env = (() => {
   const parsed = EnvSchema.safeParse(process.env);
-  const isProd = process.env.NODE_ENV === "production";
   if (!parsed.success) {
-    console.error("CRITICAL: Invalid environment variables in production:", parsed.error.flatten().fieldErrors);
+    console.error('CRITICAL: Invalid environment variables:', parsed.error.flatten().fieldErrors);
   }
   return parsed.success ? parsed.data : (process.env as any);
 })();

--- a/src/infra/auth/require-internal-auth.ts
+++ b/src/infra/auth/require-internal-auth.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireInternalToken, type InternalTokenPurpose } from './tenant-route-guard';
 import { requireAdmin } from './guards';
-import { safeCompare } from '@/lib/security/safe-compare';
+import {
+  extractInternalRequestCredentials,
+  isBootstrapTokenAuthorized,
+  isDevRuntimeEnvironment,
+  isStrictRuntimeEnvironment,
+} from '@/infra/config/internal-token-contract';
 import { structuredLogger } from '@/infra/log/logger';
 
 export type InternalAuthResult =
@@ -13,30 +18,20 @@ export interface InternalAuthOptions {
     purpose?: InternalTokenPurpose[];
     /** Require BOOTSTRAP_TOKEN header in addition to internal token */
     requireBootstrapToken?: boolean;
-    /** Block this route entirely in production (VERCEL_ENV=production) */
+    /** Block this route entirely in production/staging runtimes */
     blockInProduction?: boolean;
-    /** Block this route unless running in dev mode (NODE_ENV=development) */
+    /** Block this route unless running in dev mode */
     blockUnlessDev?: boolean;
-}
-
-function isProductionEnv(): boolean {
-    return process.env.VERCEL_ENV === 'production';
-}
-
-function isDevEnv(): boolean {
-    return process.env.NODE_ENV === 'development' || process.env.VERCEL_ENV === 'development';
 }
 
 /**
  * Unified internal auth guard.
  *
  * Tries, in order:
- * 1. Environment blocks (prod / dev-only)
- * 2. Internal token (x-internal-token header or ?token=)
+ * 1. Environment blocks (strict runtime / dev-only)
+ * 2. Internal token (x-internal-token or purpose-specific QA token)
  *    - Optionally validates x-bootstrap-token as well
  * 3. Fallback: admin session cookie
- *
- * At least one must pass; otherwise returns 401.
  */
 export async function requireInternalAuth(
     request: NextRequest,
@@ -44,8 +39,7 @@ export async function requireInternalAuth(
 ): Promise<InternalAuthResult> {
     const { purpose = ['any'], requireBootstrapToken = false, blockInProduction = false, blockUnlessDev = false } = options;
 
-    // ── Environment gates ────────────────────────────────────────────
-    if (blockInProduction && isProductionEnv()) {
+    if (blockInProduction && isStrictRuntimeEnvironment()) {
         structuredLogger.warn('internal_auth_blocked_production', {
             route: request.nextUrl.pathname,
             eventType: 'internal_auth',
@@ -59,7 +53,7 @@ export async function requireInternalAuth(
         };
     }
 
-    if (blockUnlessDev && !isDevEnv()) {
+    if (blockUnlessDev && !isDevRuntimeEnvironment()) {
         return {
             ok: false,
             response: NextResponse.json(
@@ -69,16 +63,12 @@ export async function requireInternalAuth(
         };
     }
 
-    // ── Internal token path ──────────────────────────────────────────
+    const credentials = extractInternalRequestCredentials(request);
     const tokenResult = requireInternalToken(request, { purpose });
 
     if (tokenResult.ok) {
-        // If bootstrap token is also required, validate it separately
         if (requireBootstrapToken) {
-            const bootstrapToken = request.headers.get('x-bootstrap-token');
-            const expectedBootstrapToken = process.env.BOOTSTRAP_TOKEN;
-
-            if (!expectedBootstrapToken) {
+            if (!process.env.BOOTSTRAP_TOKEN?.trim()) {
                 return {
                     ok: false,
                     response: NextResponse.json(
@@ -88,7 +78,7 @@ export async function requireInternalAuth(
                 };
             }
 
-            if (!safeCompare(bootstrapToken, expectedBootstrapToken)) {
+            if (!isBootstrapTokenAuthorized(credentials.bootstrapToken)) {
                 structuredLogger.warn('internal_auth_bootstrap_token_mismatch', {
                     route: request.nextUrl.pathname,
                     eventType: 'internal_auth',
@@ -106,26 +96,11 @@ export async function requireInternalAuth(
         return { ok: true, source: 'internal_token' };
     }
 
-    // ── QA token path (for qa_bootstrap purpose) ─────────────────────
-    if (purpose.includes('qa_bootstrap') || purpose.includes('any')) {
-        const qaToken = request.headers.get('x-qa-token') || request.nextUrl.searchParams.get('token');
-        const serverQaToken = process.env.QA_BOOTSTRAP_TOKEN?.trim()
-            || (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true'
-                ? process.env.INTERNAL_TOKEN?.trim()
-                : undefined);
-
-        if (serverQaToken && qaToken && safeCompare(qaToken, serverQaToken)) {
-            return { ok: true, source: 'bootstrap_token' };
-        }
-    }
-
-    // ── Admin session fallback ───────────────────────────────────────
     const adminResult = await requireAdmin(request);
     if (adminResult.ok) {
         return { ok: true, source: 'admin_session', tenantId: adminResult.session.tenantId };
     }
 
-    // ── All paths failed ─────────────────────────────────────────────
     return {
         ok: false,
         response: NextResponse.json(

--- a/src/infra/auth/tenant-route-guard.ts
+++ b/src/infra/auth/tenant-route-guard.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSessionUser, type SessionPayload } from './session';
-import { safeCompare } from '../../lib/security/safe-compare';
+import {
+  extractInternalRequestCredentials,
+  isInternalTokenAuthorizedForPurpose,
+  type InternalTokenPurpose,
+} from '../config/internal-token-contract';
 
 export function extractTenantIdFromTenantRoute(request: NextRequest): string {
   const segments = request.nextUrl.pathname.split('/').filter(Boolean);
@@ -69,42 +73,26 @@ export async function requireAdminSession(
   return { ok: true, sessionUser, tenantId: sessionUser.tenantId };
 }
 
-import { getInternalExportTokenOrThrow } from '../config/internal-token';
-
-export type InternalTokenPurpose = 'diag' | 'export' | 'jobs' | 'qa_bootstrap' | 'any';
-
 export function requireInternalToken(
   request: NextRequest,
-  options: { purpose?: InternalTokenPurpose[] } = { purpose: ['any'] }
+  options: { purpose?: InternalTokenPurpose[] } = { purpose: ['any'] },
 ): { ok: true } | { ok: false; response: NextResponse } {
-  const token = request.headers.get('x-internal-token') || new URL(request.url).searchParams.get('token');
-  const qaToken = request.headers.get('x-qa-bootstrap'); // Fallback for QA E2E
   const purposes = options.purpose || ['any'];
+  const credentials = extractInternalRequestCredentials(request);
 
-  // QA Bootstrap
-  if (purposes.includes('qa_bootstrap') || purposes.includes('any')) {
-    if (safeCompare(qaToken, process.env.QA_BOOTSTRAP_TOKEN)) return { ok: true };
+  const isAuthorized = purposes.some(purpose => isInternalTokenAuthorizedForPurpose(purpose, credentials));
+
+  if (isAuthorized) {
+    return { ok: true };
   }
 
-  // Jobs / Cron
-  if (purposes.includes('jobs') || purposes.includes('any')) {
-    if (safeCompare(token, process.env.INTERNAL_JOB_TOKEN)) return { ok: true };
-    if (safeCompare(token, process.env.INTERNAL_TOKEN)) return { ok: true }; // legacy fallback
-  }
-
-  // Diag & Export
-  if (purposes.includes('diag') || purposes.includes('export') || purposes.includes('any')) {
-    // try/catch so we don't break routes that don't need export token if it's missing in prod
-    try {
-      const diagOrExportToken = getInternalExportTokenOrThrow();
-      if (safeCompare(token, diagOrExportToken)) return { ok: true };
-    } catch {
-      // Proceed to fallback error below if token is not configured and we are in prod
-    }
-    // Also check explicit env vars just in case
-    if (safeCompare(token, process.env.INTERNAL_DIAG_TOKEN)) return { ok: true };
-    if (safeCompare(token, process.env.INTERNAL_EXPORT_TOKEN)) return { ok: true };
-  }
-
-  return { ok: false, response: NextResponse.json({ error: 'UNAUTHORIZED', message: 'Internal token missing or invalid' }, { status: 401 }) };
+  return {
+    ok: false,
+    response: NextResponse.json(
+      { error: 'UNAUTHORIZED', message: 'Internal token missing or invalid' },
+      { status: 401 },
+    ),
+  };
 }
+
+export type { InternalTokenPurpose };

--- a/src/infra/config/internal-token-contract.ts
+++ b/src/infra/config/internal-token-contract.ts
@@ -1,0 +1,134 @@
+import { safeCompare } from '@/lib/security/safe-compare';
+
+export type InternalTokenPurpose = 'diag' | 'export' | 'jobs' | 'qa_bootstrap' | 'any';
+
+export const INTERNAL_TOKEN_ENV_CONTRACT = {
+  diag: {
+    official: ['INTERNAL_DIAG_TOKEN'],
+    legacy: [],
+  },
+  export: {
+    official: ['INTERNAL_EXPORT_TOKEN'],
+    legacy: [],
+  },
+  jobs: {
+    official: ['INTERNAL_JOB_TOKEN'],
+    legacy: ['INTERNAL_TOKEN'],
+  },
+  qa_bootstrap: {
+    official: ['QA_BOOTSTRAP_TOKEN'],
+    legacy: [],
+  },
+} as const;
+
+export const INTERNAL_BOOTSTRAP_ENV_CONTRACT = {
+  official: 'BOOTSTRAP_TOKEN',
+} as const;
+
+export function isStrictRuntimeEnvironment(): boolean {
+  return (
+    process.env.NODE_ENV === 'production' ||
+    process.env.VERCEL_ENV === 'production' ||
+    process.env.VERCEL_ENV === 'preview' ||
+    process.env.APP_ENV === 'staging'
+  );
+}
+
+export function isDevRuntimeEnvironment(): boolean {
+  return !isStrictRuntimeEnvironment() && process.env.NODE_ENV === 'development';
+}
+
+function trimEnvValue(key: string): string | null {
+  const value = process.env[key]?.trim();
+  return value ? value : null;
+}
+
+function dedupe(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+export function getInternalTokenEnvKeys(purpose: Exclude<InternalTokenPurpose, 'any'>): {
+  official: readonly string[];
+  legacy: readonly string[];
+} {
+  return INTERNAL_TOKEN_ENV_CONTRACT[purpose];
+}
+
+export function getOfficialInternalTokens(purpose: Exclude<InternalTokenPurpose, 'any'>): string[] {
+  return dedupe(getInternalTokenEnvKeys(purpose).official.map(trimEnvValue));
+}
+
+export function getAcceptedInternalTokens(purpose: Exclude<InternalTokenPurpose, 'any'>): string[] {
+  const envKeys = getInternalTokenEnvKeys(purpose);
+  return dedupe([...envKeys.official, ...envKeys.legacy].map(trimEnvValue));
+}
+
+export function getAllAcceptedInternalTokens(): string[] {
+  return dedupe([
+    ...getAcceptedInternalTokens('diag'),
+    ...getAcceptedInternalTokens('export'),
+    ...getAcceptedInternalTokens('jobs'),
+  ]);
+}
+
+export function getAcceptedQaBootstrapTokens(): string[] {
+  return getAcceptedInternalTokens('qa_bootstrap');
+}
+
+export function getMissingCriticalInternalTokenEnvs(): string[] {
+  const purposes: Array<Exclude<InternalTokenPurpose, 'any' | 'qa_bootstrap'>> = ['diag', 'export', 'jobs'];
+  const missing: string[] = [];
+
+  for (const purpose of purposes) {
+    const configuredOfficial = getOfficialInternalTokens(purpose);
+    if (configuredOfficial.length === 0) {
+      missing.push(...getInternalTokenEnvKeys(purpose).official);
+    }
+  }
+
+  return missing;
+}
+
+export interface InternalRequestCredentials {
+  token: string | null;
+  qaToken: string | null;
+  bootstrapToken: string | null;
+}
+
+export function extractInternalRequestCredentials(request: { headers: Pick<Headers, 'get'>; nextUrl?: { searchParams: URLSearchParams }; url?: string }): InternalRequestCredentials {
+  const searchParams = request.nextUrl?.searchParams ?? new URL(request.url ?? 'http://localhost').searchParams;
+
+  return {
+    token: request.headers.get('x-internal-token') || searchParams.get('token'),
+    qaToken:
+      request.headers.get('x-qa-token') ||
+      request.headers.get('x-qa-bootstrap') ||
+      searchParams.get('qaToken') ||
+      searchParams.get('token'),
+    bootstrapToken: request.headers.get('x-bootstrap-token'),
+  };
+}
+
+export function isInternalTokenAuthorizedForPurpose(
+  purpose: InternalTokenPurpose,
+  credentials: Pick<InternalRequestCredentials, 'token' | 'qaToken'>,
+): boolean {
+  if (purpose === 'any') {
+    return (
+      isInternalTokenAuthorizedForPurpose('diag', credentials) ||
+      isInternalTokenAuthorizedForPurpose('export', credentials) ||
+      isInternalTokenAuthorizedForPurpose('jobs', credentials)
+    );
+  }
+
+  if (purpose === 'qa_bootstrap') {
+    return getAcceptedQaBootstrapTokens().some(candidate => safeCompare(credentials.qaToken, candidate));
+  }
+
+  return getAcceptedInternalTokens(purpose).some(candidate => safeCompare(credentials.token, candidate));
+}
+
+export function isBootstrapTokenAuthorized(token: string | null | undefined): boolean {
+  const expected = trimEnvValue(INTERNAL_BOOTSTRAP_ENV_CONTRACT.official);
+  return Boolean(expected && safeCompare(token, expected));
+}

--- a/src/infra/config/internal-token.ts
+++ b/src/infra/config/internal-token.ts
@@ -1,29 +1,32 @@
 import crypto from 'node:crypto';
 import { logger } from '../logger';
+import {
+  getAcceptedInternalTokens,
+  getOfficialInternalTokens,
+  isDevRuntimeEnvironment,
+  isStrictRuntimeEnvironment,
+  type InternalTokenPurpose,
+} from './internal-token-contract';
 
 let generatedDevToken: string | null = null;
 let warned = false;
 
-function isProd(): boolean {
-  return process.env.NODE_ENV === 'production';
-}
-
-function getConfiguredInternalToken(): string | null {
-  const diagToken = process.env.INTERNAL_DIAG_TOKEN?.trim();
+function getDiagOrExportToken(): string | null {
+  const diagToken = getOfficialInternalTokens('diag')[0];
   if (diagToken) return diagToken;
 
-  const exportToken = process.env.INTERNAL_EXPORT_TOKEN?.trim();
+  const exportToken = getOfficialInternalTokens('export')[0];
   if (exportToken) return exportToken;
 
   return null;
 }
 
 export function getInternalExportTokenOrThrow(): string {
-  const configured = getConfiguredInternalToken();
+  const configured = getDiagOrExportToken();
   if (configured) return configured;
 
-  if (isProd()) {
-    throw new Error('INTERNAL_DIAG_TOKEN or INTERNAL_EXPORT_TOKEN is required in production');
+  if (isStrictRuntimeEnvironment()) {
+    throw new Error('INTERNAL_DIAG_TOKEN or INTERNAL_EXPORT_TOKEN is required in staging/production runtimes');
   }
 
   if (!generatedDevToken) {
@@ -43,11 +46,22 @@ export function getInternalExportTokenOrThrow(): string {
   return generatedDevToken;
 }
 
-export function isInternalTokenAuthorized(token: string | null | undefined): boolean {
-  try {
-    const expected = getInternalExportTokenOrThrow();
-    return Boolean(token && token === expected);
-  } catch {
-    return false;
+export function getInternalTokenForPurposeOrThrow(
+  purpose: Exclude<InternalTokenPurpose, 'any' | 'qa_bootstrap'>,
+): string {
+  const configured = getAcceptedInternalTokens(purpose)[0];
+  if (configured) return configured;
+
+  if (purpose === 'export' || purpose === 'diag') {
+    return getInternalExportTokenOrThrow();
   }
+
+  throw new Error(`Missing internal token for purpose: ${purpose}`);
 }
+
+export function isInternalTokenAuthorized(token: string | null | undefined): boolean {
+  return getAcceptedInternalTokens('export').some(candidate => candidate === token)
+    || getAcceptedInternalTokens('diag').some(candidate => candidate === token);
+}
+
+export { isDevRuntimeEnvironment, isStrictRuntimeEnvironment };

--- a/src/infra/env/require-env.ts
+++ b/src/infra/env/require-env.ts
@@ -1,12 +1,13 @@
+import { getMissingCriticalInternalTokenEnvs, isStrictRuntimeEnvironment } from '../config/internal-token-contract';
+
 export function requireEnv(key: string, fallback?: string): string {
     const val = process.env[key];
     if (!val) {
         if (fallback !== undefined) {
-            if (process.env.NODE_ENV !== "production") {
+            if (!isStrictRuntimeEnvironment()) {
                 console.warn(`[WARN] Missing env ${key}. Using fallback in non-production environment.`);
                 return fallback;
             }
-            return fallback; // Allow fallback in production if explicitly provided
         }
         throw new Error(`CRITICAL STARTUP ERROR: Missing required environment variable: ${key}`);
     }
@@ -14,16 +15,20 @@ export function requireEnv(key: string, fallback?: string): string {
 }
 
 export function assertCriticalEnvSetup() {
-    if (process.env.NODE_ENV === "test" || process.env.CI === "true") return; // Bypass rigid checks for CI runners
+    if (process.env.NODE_ENV === 'test' || process.env.CI === 'true') return;
 
-    requireEnv("DATABASE_URL");
+    requireEnv('DATABASE_URL');
+    requireEnv('NEXT_PUBLIC_APP_URL', 'http://localhost:3000');
 
-    if (process.env.NODE_ENV === 'production') {
-        requireEnv("INTERNAL_TOKEN");
+    if (isStrictRuntimeEnvironment()) {
+        requireEnv('AUTH_SECRET');
+        const missingInternalTokenEnvs = getMissingCriticalInternalTokenEnvs();
+        if (missingInternalTokenEnvs.length > 0) {
+            throw new Error(
+                `CRITICAL STARTUP ERROR: Missing required internal auth env(s): ${missingInternalTokenEnvs.join(', ')}`,
+            );
+        }
     }
 
-    // NEXT_PUBLIC_APP_URL is technically optional for Next.js internal links but critical for hooks
-    requireEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3000");
-
-    console.info("✅ Critical Environment Variables Verified.");
+    console.info('✅ Critical Environment Variables Verified.');
 }

--- a/src/infra/security/__tests__/production-smoke.test.ts
+++ b/src/infra/security/__tests__/production-smoke.test.ts
@@ -47,12 +47,12 @@ describe('Production Smoke Test - Middleware', () => {
         expect(res.status).not.toBe(401);
     });
 
-    it('NÃO bloqueia /api/internal/* em dev', async () => {
+    it('mantem fail-closed em dev quando nenhum token interno é enviado', async () => {
         vi.stubEnv('NODE_ENV', 'development');
 
         const req = new NextRequest('http://localhost:3000/api/internal/diag');
         const res = await middleware(req) as NextResponse;
 
-        expect(res.status).not.toBe(401);
+        expect(res.status).toBe(401);
     });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,9 @@
 import { jwtVerify, type JWTPayload } from 'jose';
 import { NextRequest, NextResponse } from 'next/server';
-import { safeCompare } from './lib/security/safe-compare';
+import {
+    extractInternalRequestCredentials,
+    isInternalTokenAuthorizedForPurpose,
+} from './infra/config/internal-token-contract';
 import { logEdgeSecurityEvent } from './lib/security/edge-logger';
 
 const SESSION_COOKIE_NAME = 'condstore_session';
@@ -95,9 +98,6 @@ function forbiddenJsonResponse(message = 'Forbidden'): NextResponse {
 export async function middleware(req: NextRequest) {
     const pathname = req.nextUrl.pathname;
 
-    // ==========================================
-    // RULE 0: PUBLIC MATCHERS & KILL SWITCH
-    // ==========================================
     if (pathname.startsWith('/api/public/')) {
         if (process.env.PUBLIC_ENDPOINTS_DISABLED === 'true') {
             await logEdgeSecurityEvent({
@@ -111,22 +111,16 @@ export async function middleware(req: NextRequest) {
                 headers: { 'content-type': 'application/json' },
             });
         }
-        // Public endpoints have no token auth, proceed to app router
         return NextResponse.next();
     }
 
-    // Clone headers so we can set/strip things to pass down to Next
     const requestHeaders = new Headers(req.headers);
-
-    // Context for telemetry
     const clientIp = requestHeaders.get('x-forwarded-for');
     const requestId = requestHeaders.get('x-request-id') || 'unknown';
 
-    // Security Hardening: Strip potentially spoofable headers from the incoming client request
     const spoofedHeadersDetected = ['x-tenant-id', 'x-auth-tenant-id', 'x-auth-role', 'x-auth-user-id', 'x-auth-email', 'x-role', 'x-user-id'].some(h => requestHeaders.has(h));
 
     if (spoofedHeadersDetected) {
-        // Technically we are just stripping them, but we want to log the attempt
         await logEdgeSecurityEvent({
             requestId,
             route: pathname,
@@ -143,39 +137,13 @@ export async function middleware(req: NextRequest) {
     requestHeaders.delete('x-role');
     requestHeaders.delete('x-user-id');
 
-    // ==========================================
-    // RULE 1: /api/internal/*
-    // ==========================================
     if (pathname.startsWith('/api/internal/')) {
-        const token = req.headers.get('x-internal-token') || req.headers.get('x-qa-token') || req.nextUrl.searchParams.get('token');
-
-        const diagToken = process.env.INTERNAL_DIAG_TOKEN?.trim();
-        const exportToken = process.env.INTERNAL_EXPORT_TOKEN?.trim();
-        const jobToken = process.env.INTERNAL_JOB_TOKEN?.trim();
-        const internalToken = process.env.INTERNAL_TOKEN?.trim();
-        const qaToken = process.env.QA_BOOTSTRAP_TOKEN?.trim();
-
-        // Specific endpoints that might allow token via QS (e.g. data retention job callback from Vercel cron)
-        // Here we strictly check header or query using the central tokens.
-
-        // Exception specifically for QA automation
-        const isQaBootstrap = pathname === '/api/internal/qa/bootstrap-session' || pathname === '/api/internal/qa/setup';
-        const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
-        const hasGithubHeader = req.headers.get('x-github-actions') === 'true';
-
-        // Exception for local development
-        const isLocalDev = process.env.NODE_ENV === 'development';
-
-        let isAuthorized =
-            isLocalDev ||
-            safeCompare(token, diagToken) ||
-            safeCompare(token, exportToken) ||
-            safeCompare(token, jobToken) ||
-            safeCompare(token, internalToken);
-
-        if (!isAuthorized && isQaBootstrap && isGithubActions && hasGithubHeader && safeCompare(token, qaToken)) {
-            isAuthorized = true;
-        }
+        const credentials = extractInternalRequestCredentials(req);
+        const isAuthorized =
+            isInternalTokenAuthorizedForPurpose('any', credentials) ||
+            (pathname === '/api/internal/qa/bootstrap-session' || pathname === '/api/internal/qa/setup'
+                ? isInternalTokenAuthorizedForPurpose('qa_bootstrap', credentials)
+                : false);
 
         if (!isAuthorized) {
             await logEdgeSecurityEvent({
@@ -190,9 +158,6 @@ export async function middleware(req: NextRequest) {
         return NextResponse.next({ request: { headers: requestHeaders } });
     }
 
-    // ==========================================
-    // RULE 2: Session Check for cockpit, admin, tenants
-    // ==========================================
     const cookieToken = req.cookies.get(SESSION_COOKIE_NAME)?.value;
     if (!cookieToken) {
         if (pathname.startsWith('/api/cockpit/') || pathname.startsWith('/api/admin/') || pathname.startsWith('/api/tenants/') || pathname.startsWith('/api/orders/')) {
@@ -205,8 +170,6 @@ export async function middleware(req: NextRequest) {
             return unauthorizedJsonResponse('Missing authentication token');
         }
     }
-
-    // NOTE: If missing but not hitting those above, we'd skip (though matcher prevents this code path)
 
     if (cookieToken) {
         const session = await verifyMiddlewareSessionToken(cookieToken);
@@ -221,16 +184,11 @@ export async function middleware(req: NextRequest) {
             return unauthorizedJsonResponse('Invalid or expired authentication token');
         }
 
-        // Set enriched trusted headers for downstream API handlers
         requestHeaders.set('x-auth-tenant-id', session.tenantId);
         requestHeaders.set('x-auth-user-id', session.sub);
         requestHeaders.set('x-auth-role', session.role);
 
-        // ==========================================
-        // RULE 3: /api/tenants/* 
-        // ==========================================
         if (pathname.startsWith('/api/tenants/')) {
-            // E.g. /api/tenants/tnt-xyz/health
             const segments = pathname.split('/').filter(Boolean);
             const idx = segments.indexOf('tenants');
             const routeTenantId = segments[idx + 1]?.trim();

--- a/src/tests/operational-event-bus.test.ts
+++ b/src/tests/operational-event-bus.test.ts
@@ -64,7 +64,7 @@ describe('publishOperationalEvent', () => {
         })).resolves.toBeUndefined();
 
         expect(mockDb.insert).toHaveBeenCalled();
-    });
+    }, 20000);
 
     it('rejects unknown domain silently (logs warn, does not throw)', async () => {
         const { structuredLogger } = await import('@/infra/log/logger');


### PR DESCRIPTION
### Motivation
- Centralize and harden internal-only authentication by introducing purpose-scoped internal tokens instead of a single `INTERNAL_TOKEN` value.
- Make runtime behavior explicit between development and strict runtimes (production/staging/preview) so missing critical internal secrets fail fast in those environments.

### Description
- Add a new contract module `src/infra/config/internal-token-contract.ts` with typed purposes (`diag`, `export`, `jobs`, `qa_bootstrap`, `any`) and helpers to extract and validate request credentials.
- Refactor internal token logic across the codebase: replace ad-hoc checks with `isInternalTokenAuthorizedForPurpose`/`extractInternalRequestCredentials`, move bootstrap token checks to `isBootstrapTokenAuthorized`, and preserve legacy aliases (`INTERNAL_TOKEN` for `jobs`, `x-qa-bootstrap` header for QA).
- Update `middleware.ts`, `tenant-route-guard.ts`, and `require-internal-auth.ts` to use the new contract and to enforce fail-closed behavior for internal routes in strict runtimes while preserving dev fallbacks where intended.
- Refactor `src/infra/config/internal-token.ts` to provide purpose-aware helpers and dev fallback generation for diag/export tokens only; expose runtime checks `isDevRuntimeEnvironment` and `isStrictRuntimeEnvironment`.
- Update environment schema (`src/env.ts`), environment validation (`src/infra/env/require-env.ts`), documentation (`README.md`, `docs/...`) and the API routes classification to list the new tokens and the internal auth contract.
- Add `src/__tests__/internal-auth-contract.test.ts` and adjust existing tests to reflect the new token expectations and timeouts in a few slow tests.

### Testing
- Unit tests added/updated: `src/__tests__/internal-auth-contract.test.ts` plus adjusted tests in `src/app/api/internal/billing/__tests__/reconcile-stripe.test.ts`, `src/core/ai/__tests__/llm-gateway.test.ts`, and `src/tests/operational-event-bus.test.ts` to align with the new contract and environment behavior.
- Ran the test suite with `npm run test:ci` (Vitest) against the modified code; unit tests covering internal auth and adjusted suites passed locally during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0f2beab483318f9a9ef7cfc5f15d)