### PR TITLE
MPV-25: expand Frank policy enforcement for additional high-risk actions

### DIFF
--- a/src/modules/frank/__tests__/agent-loop.test.ts
+++ b/src/modules/frank/__tests__/agent-loop.test.ts
@@ -29,6 +29,22 @@ describe('Frank agent loop (minimal)', () => {
         expect(result.data).toEqual({ quoteId: 'q-1' });
     });
 
+
+    it('blocks high-risk approval request when quote context is missing', async () => {
+        const result = await runFrankAgentTool({
+            requestId: 'req-approval-1',
+            action: 'REQUEST_QUOTE_APPROVAL',
+            quoteStatus: null,
+            execute: async () => ({ ok: true }),
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe('BLOCKED_BY_POLICY');
+        expect(result.errorCode).toBe('POLICY_BLOCKED');
+        expect(result.errorMessage).toContain('cotação inexistente');
+        expect(result.nextAllowedActions).toEqual(['READ_QUOTE_CONTEXT']);
+    });
+
     it('always returns ToolResult shape on execution failure', async () => {
         const result = await runFrankAgentTool({
             requestId: 'req-3',

--- a/src/modules/frank/agent-loop.ts
+++ b/src/modules/frank/agent-loop.ts
@@ -42,7 +42,7 @@ export interface FrankPlannerInput {
 
 const ACTION_RISK_MAP: Record<FrankAgentAction, FrankRiskLevel> = {
     READ_QUOTE_CONTEXT: 'LOW_RISK',
-    REQUEST_QUOTE_APPROVAL: 'MEDIUM_RISK',
+    REQUEST_QUOTE_APPROVAL: 'HIGH_RISK',
     CREATE_ORDER_FROM_ACCEPTED_QUOTE: 'HIGH_RISK',
 };
 
@@ -54,22 +54,44 @@ export function decideNextAction(input: FrankPlannerInput, state: FrankAgentStat
     return input.requestedAction;
 }
 
+function resolveNextAllowedActions(quoteStatus: string | null): FrankAgentAction[] {
+    if (quoteStatus === 'ACCEPTED') {
+        return ['READ_QUOTE_CONTEXT', 'CREATE_ORDER_FROM_ACCEPTED_QUOTE'];
+    }
+
+    if (quoteStatus === 'SENT' || quoteStatus === 'DRAFT') {
+        return ['READ_QUOTE_CONTEXT', 'REQUEST_QUOTE_APPROVAL'];
+    }
+
+    return ['READ_QUOTE_CONTEXT'];
+}
+
 export function evaluatePolicy(input: FrankPolicyInput): FrankPolicyDecision {
     const riskLevel = ACTION_RISK_MAP[input.action];
+    const nextAllowedActions = resolveNextAllowedActions(input.quoteStatus);
 
-    if (riskLevel === 'HIGH_RISK' && input.quoteStatus !== 'ACCEPTED') {
+    if (input.action === 'REQUEST_QUOTE_APPROVAL' && !input.quoteStatus) {
+        return {
+            riskLevel,
+            allowed: false,
+            reason: 'Ação bloqueada: cotação inexistente para solicitar aprovação.',
+            nextAllowedActions,
+        };
+    }
+
+    if (input.action === 'CREATE_ORDER_FROM_ACCEPTED_QUOTE' && input.quoteStatus !== 'ACCEPTED') {
         return {
             riskLevel,
             allowed: false,
             reason: 'A cotacao precisa estar aprovada antes de criar o pedido.',
-            nextAllowedActions: ['READ_QUOTE_CONTEXT', 'REQUEST_QUOTE_APPROVAL'],
+            nextAllowedActions,
         };
     }
 
     return {
         riskLevel,
         allowed: true,
-        nextAllowedActions: ['READ_QUOTE_CONTEXT', 'REQUEST_QUOTE_APPROVAL', 'CREATE_ORDER_FROM_ACCEPTED_QUOTE'],
+        nextAllowedActions,
     };
 }
 
@@ -119,10 +141,12 @@ export async function runFrankAgentTool(params: {
             },
         };
 
-        logger.info('frank_agent_loop_execution', {
+        logger.warn('frank_agent_loop_execution_blocked', {
             requestId: params.requestId,
             action: plannedAction,
             outcome: blockedResult.status,
+            reason: blockedResult.errorMessage,
+            riskLevel: policy.riskLevel,
             durationMs: Date.now() - start,
         });
 
@@ -152,6 +176,7 @@ export async function runFrankAgentTool(params: {
             requestId: params.requestId,
             action: plannedAction,
             outcome: success.status,
+            riskLevel: policy.riskLevel,
             durationMs: Date.now() - start,
         });
 
@@ -175,6 +200,7 @@ export async function runFrankAgentTool(params: {
             requestId: params.requestId,
             action: plannedAction,
             outcome: failed.status,
+            riskLevel: policy.riskLevel,
             durationMs: Date.now() - start,
         });
 

--- a/src/modules/frank/tools/tool-policy.ts
+++ b/src/modules/frank/tools/tool-policy.ts
@@ -21,7 +21,12 @@ export interface FrankToolPolicyDecision {
     reason?: string;
 }
 
-const HIGH_RISK_ACTIONS: ReadonlySet<FrankToolAction> = new Set(['create_order_from_quote']);
+const HIGH_RISK_ACTIONS: ReadonlySet<FrankToolAction> = new Set([
+    'create_quote',
+    'create_order_from_quote',
+]);
+
+const HIGH_RISK_BLOCK_REASON = 'missing_high_risk_precondition';
 
 export function evaluateFrankToolPolicy(
     action: FrankToolAction,
@@ -35,13 +40,14 @@ export function evaluateFrankToolPolicy(
             requestId: context.requestId,
             action,
             riskLevel,
-            reason: 'missing_high_risk_precondition',
+            reason: HIGH_RISK_BLOCK_REASON,
+            requiredValidation: 'allowHighRisk=true',
         });
 
         return {
             allowed: false,
             riskLevel,
-            reason: 'missing_high_risk_precondition',
+            reason: HIGH_RISK_BLOCK_REASON,
         };
     }
 

--- a/src/modules/frank/tools/tool-runner.test.ts
+++ b/src/modules/frank/tools/tool-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { simulateFreightMock, createOrderMock, getOrderStatusMock } = vi.hoisted(() => ({
     simulateFreightMock: vi.fn(),
@@ -27,6 +27,9 @@ vi.mock('./read-only/getShipmentStatus.tool', () => ({
 import { runTool } from './tool-runner';
 
 describe('runTool', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
     it('executes valid low-risk tools and normalizes response', async () => {
         simulateFreightMock.mockResolvedValueOnce({ carrier: 'x', price: 10, deliveryDays: 2 });
 
@@ -49,7 +52,7 @@ describe('runTool', () => {
         expect(result.error).toBeNull();
     });
 
-    it('blocks high-risk tool without policy precondition', async () => {
+    it('blocks high-risk order creation tool without policy precondition', async () => {
         const result = await runTool(
             'create_order_from_quote',
             {
@@ -68,6 +71,50 @@ describe('runTool', () => {
         expect(result.ok).toBe(false);
         expect(result.error?.code).toBe('POLICY_BLOCKED');
         expect(createOrderMock).not.toHaveBeenCalled();
+    });
+
+
+    it('blocks high-risk quote creation tool without policy precondition', async () => {
+        const result = await runTool(
+            'create_quote',
+            {
+                tenantId: 'tenant-1',
+                productId: 'prod-1',
+                quantity: 1,
+                destinationZip: '01001000',
+            },
+            {
+                tenantId: 'tenant-1',
+                requestId: 'req-quote-blocked',
+            },
+        );
+
+        expect(result.ok).toBe(false);
+        expect(result.error?.code).toBe('POLICY_BLOCKED');
+        expect(simulateFreightMock).not.toHaveBeenCalled();
+    });
+
+    it('allows high-risk tools when explicit precondition is provided', async () => {
+        simulateFreightMock.mockResolvedValueOnce({ carrier: 'x', price: 11, deliveryDays: 3 });
+
+        const result = await runTool(
+            'create_quote',
+            {
+                tenantId: 'tenant-1',
+                productId: 'prod-1',
+                quantity: 1,
+                destinationZip: '01001000',
+            },
+            {
+                tenantId: 'tenant-1',
+                requestId: 'req-quote-allowed',
+                allowHighRisk: true,
+            },
+        );
+
+        expect(result.ok).toBe(true);
+        expect(result.error).toBeNull();
+        expect(result.data).toEqual({ carrier: 'x', price: 11, deliveryDays: 3 });
     });
 
     it('returns structured execution error on tool failure', async () => {


### PR DESCRIPTION
### Motivation
- Harden Frank policy layer to prevent critical actions from executing without explicit validation and to improve observable, consistent blocking behavior. 
- Align tool-level and agent-loop risk classification so both layers block the same HIGH_RISK operations.
- Provide clearer, structured logs for blocked actions to aid operations and audits.

### Description
- Reclassified `REQUEST_QUOTE_APPROVAL` as `HIGH_RISK` in the Frank agent loop and centralized `nextAllowedActions` derivation based on quote status to unify allow/block responses (`src/modules/frank/agent-loop.ts`).
- Emitted explicit blocked telemetry with richer context by introducing `frank_agent_loop_execution_blocked` logs including `reason` and `riskLevel` and kept successful/failed runs observable (`agent-loop` logging updates).
- Expanded tool policy to mark both `create_quote` and `create_order_from_quote` as `HIGH_RISK`, introduced `HIGH_RISK_BLOCK_REASON` and added `requiredValidation: 'allowHighRisk=true'` metadata to policy-block logs (`src/modules/frank/tools/tool-policy.ts`).
- Added tests and test hardening: new/updated unit tests cover blocking approval requests when quote context is missing, blocking quote creation without precondition, and allowing quote creation when `allowHighRisk` is present; also added `beforeEach` to clear mocks (`src/modules/frank/__tests__/agent-loop.test.ts`, `src/modules/frank/tools/tool-runner.test.ts`).

### Testing
- Ran targeted unit suites with Vitest: `npm run test:win-stable -- src/modules/frank/tools/tool-runner.test.ts src/modules/frank/__tests__/agent-loop.test.ts` and all tests passed (9 tests total) ✅.
- Ran static checks: `npm run lint` completed successfully ✅ and `npm run typecheck` completed successfully ✅.
- Guardrail / scope helpers could not be validated in this environment: attempted `ALLOW_FROZEN_SURFACE_CHANGES=1 npm run guardrail:mvp-freeze` and `npm run scope:pr-tests` but both failed due to repository diff resolution in CI environment (`fatal: ambiguous argument 'origin/main...HEAD'`), so their checks are unavailable here ⚠️.
- Summary of commands executed: `npm run test:win-stable -- src/modules/frank/tools/tool-runner.test.ts src/modules/frank/__tests__/agent-loop.test.ts`, `npm run lint`, `npm run typecheck`, `ALLOW_FROZEN_SURFACE_CHANGES=1 npm run guardrail:mvp-freeze` (failed), `npm run scope:pr-tests` (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdde2b4f788331b6479ff01e06d418)