### PR TITLE
feat(tudico): add isolated Tudico MVP (SDD) — tools registry, memory layer, hub & API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -174,3 +174,17 @@ Gates executados em CI:
 - O código contém módulos/UI em estágios de maturidade diferentes (partes com mock/placeholder coexistem com serviços e schema já reais).
 - Em runtime estrito, segredos críticos (auth, tokens internos, redis e integrações) devem estar presentes; não assumir fallback de desenvolvimento.
 - Qualquer novo fluxo deve manter: escopo de tenant, logs estruturados, tolerância a falhas externas e uso do gateway central para IA.
+
+
+## 13) Tudico (agente de pesquisa isolado - MVP)
+
+A arquitetura inclui um MVP isolado do Tudico para estudo da frente Estrutura Quântica-Relacional:
+
+- **UI**: `src/app/(app)/tudico/page.tsx` (hub inicial com claims, glossary, inconsistências e perguntas em aberto).
+- **API**: `src/app/api/tudico/query/route.ts` (tenant-scoped por `x-auth-tenant-id`).
+- **Domínio**: `src/modules/tudico/**` (context manager/memory, tools registry obrigatório e output protocol epistemológico).
+
+Invariantes:
+- Tudico não chama gateway de IA nem providers externos na fase 1.
+- Tudico não integra com Frank e não executa fluxos operacionais do CONDSTORE.
+- Toda consulta mantém escopo por tenant.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ Sem `.env.example` versionado, então use como base os pontos abaixo.
 - **IA Frank**: existe runtime, tools e worker; operação pode ser restringida por flags (`FRANK_RUNTIME_ENABLED`, `FRANK_RUNTIME_MODE`), permitindo modo supervisionado.
 - **Maturidade heterogênea de UI**: há telas e módulos que ainda usam partes mock/placeholder no front-end enquanto o backend já possui estrutura de domínio e schema para os mesmos contextos.
 
+
+## Tudico MVP (Pesquisa isolada)
+
+Foi adicionada uma superfície isolada de pesquisa em `/(app)/tudico` com API dedicada em `/api/tudico/query`, sem integração com Frank runtime nem com fluxos operacionais de CRM/frete/cockpit.
+
+Componentes principais:
+- `src/modules/tudico/**`: core loop mínimo, memory/context layer, registry de tools e protocolo epistemológico.
+- `docs/tudico/spec.md` e `docs/tudico/design.md`: fases S (Spec) e D (Design) do fluxo SDD.
+- `docs/tudico/master-document.md`: documento mestre inicial para ingestão.
+
+Esse MVP usa store em memória tenant-scoped na fase 1 para reduzir complexidade e preservar isolamento de escopo.
+
 ## Documento técnico complementar
 
 Para mapa arquitetural interno e invariantes, veja [`ARCHITECTURE.md`](./ARCHITECTURE.md).

--- a/docs/_generated/routes-inventory.md
+++ b/docs/_generated/routes-inventory.md
@@ -218,6 +218,7 @@
 | `/api/tenants/[tenantId]/secrets/rotate` | API |
 | `/api/tenants/[tenantId]/secrets/test` | API |
 | `/api/tenants/[tenantId]/settings` | API |
+| `/api/tudico/query` | API |
 | `/api/webhook` | API |
 | `/api/webhook/fallback` | API |
 | `/api/webhook/stripe` | API |
@@ -344,6 +345,7 @@
 | `/tecnologias` | Page |
 | `/tenant` | Page |
 | `/termos` | Page |
+| `/tudico` | Page |
 | `/valores` | Page |
 | `/vendas/clientes` | Page |
 | `/vendas/cotacao` | Page |

--- a/docs/routes-registry.md
+++ b/docs/routes-registry.md
@@ -351,3 +351,5 @@
 | /api/cockpit/governance/playbooks/[playbookId]/apply | GET/POST | internal | requireAdmin | cockpit | live | Added |
 | /api/cockpit/governance/playbooks/metrics | GET/POST | internal | requireAdmin | cockpit | live | Added |
 | /api/cockpit/frank/feed | POST | internal | requireAdmin | cockpit | live | Added |
+| /api/tudico/query | POST | internal | required | tudico | live | Endpoint isolado do Tudico para consultas epistemológicas tenant-scoped |
+| /tudico | GET | internal | required | tudico | live | Hub inicial do Tudico com claims, glossary, inconsistências e perguntas em aberto |

--- a/docs/tudico/design.md
+++ b/docs/tudico/design.md
@@ -1,0 +1,98 @@
+# Tudico MVP Design (Fase D)
+
+## Arquitetura mínima
+
+```txt
+Tudico Web Hub (/tudico)
+  -> TudicoService
+     -> ContextManager (master document + entities)
+     -> ToolRegistry (7 tools obrigatórias)
+     -> OutputProtocol (estrutura epistemológica)
+     -> MemoryStore (tenant-scoped, in-memory seed)
+```
+
+## Stack fase 1
+
+- **Store relacional/JSON mínimo**: em memória (seed versionado em TypeScript) para reduzir complexidade.
+- **Banco vetorial**: adiado; substituído por indexação textual simplificada no master document.
+- **Painel web**: página Next.js server component + client component de consulta.
+- **API mínima**: `POST /api/tudico/query` tenant-scoped via headers de sessão.
+
+## Modelo de armazenamento
+
+`TudicoMemoryState` por `tenantId` contendo:
+
+- metadados do documento mestre
+- glossary entries
+- claims
+- versões de hipótese
+- open questions
+- inconsistencies
+- bibliography
+
+## Versionamento de hipótese
+
+Cada versão contém:
+
+- `id`
+- `version`
+- `summary`
+- `changes`
+- `createdAt`
+
+Comparação retorna:
+
+- versão base
+- versão alvo
+- itens adicionados
+- itens removidos
+
+## Claim registry
+
+Claim com:
+
+- `id`
+- `statement`
+- `status` (`estabelecido|plausível|conjectural|excessivo`)
+- `evidenceRefs`
+- `notes`
+
+## Inconsistency board
+
+Entrada com:
+
+- `id`
+- `description`
+- `severity` (`low|medium|high`)
+- `relatedClaimIds`
+- `action`
+
+## Fluxo de ingestão do documento mestre
+
+1. Carregar markdown base (`docs/tudico/master-document.md`).
+2. Extrair título, seções e resumo inicial.
+3. Anexar metadata no `masterDocument` do estado.
+4. Registrar log estruturado de ingestão.
+
+## Tools mínimas implementadas
+
+- `get_claim_status`
+- `compare_hypothesis_versions`
+- `fetch_glossary_term`
+- `list_open_questions`
+- `audit_response_for_extrapolation`
+- `map_concept_dependencies`
+- `summarize_regime_state`
+
+## Painel inicial
+
+Seções no hub `/tudico`:
+
+- visão geral da frente
+- estado atual do MVP em Rindler
+- claims
+- glossary
+- inconsistências
+- versões da hipótese
+- perguntas em aberto
+- formulário de consulta com protocolo epistemológico

--- a/docs/tudico/master-document.md
+++ b/docs/tudico/master-document.md
@@ -1,0 +1,21 @@
+# Estrutura Quântica-Relacional — Documento Mestre (MVP)
+
+## Estado base
+
+A frente Rindler investiga hipóteses de estrutura relacional para descrever regimes físicos em diferentes escalas sem unificação prematura.
+
+## Hipótese atual (v0.2)
+
+A estrutura observável pode ser modelada por camadas de vínculos relacionais com regimes efetivos dependentes de escala e condição de contorno.
+
+## Claims iniciais
+
+1. É possível diferenciar descrição efetiva e descrição fundamental sem colapsar o vocabulário.
+2. Mudanças de regime podem ser descritas por transições de consistência entre constraints.
+3. Analogias geométricas ajudam, mas devem ser marcadas como conjecturais.
+
+## Glossário mínimo
+
+- Regime: faixa de validade de uma descrição.
+- Constraint: restrição estrutural aplicável a um conjunto de relações.
+- Invariância relacional: propriedade preservada sob transformação admissível.

--- a/docs/tudico/spec.md
+++ b/docs/tudico/spec.md
@@ -1,0 +1,91 @@
+# Tudico MVP Spec (Fase S)
+
+## Objetivo formal
+
+O **Tudico** é um agente de pesquisa isolado para a frente **Estrutura Quântica-Relacional (Rindler)**. Ele atua como memória externa, curador de corpus, auditor conceitual e rastreador de hipóteses.
+
+## Problema que resolve no MVP
+
+- Evitar perda de contexto em iterações de estudo.
+- Separar claramente fatos estabelecidos de hipóteses e extrapolações.
+- Tornar rastreável a evolução de versões de hipótese.
+- Permitir consulta rápida a claims, glossary, inconsistências e open questions.
+
+## Non-goals (congelados neste MVP)
+
+- Não integrar com Frank runtime/training.
+- Não integrar com fluxos operacionais do CONDSTORE (CRM, frete, vendas, cockpit operacional).
+- Não implementar coding-agent genérico.
+- Não implementar multi-agent avançado.
+- Não implementar knowledge graph sofisticado.
+
+## Tipos de consulta suportados
+
+1. **Status de claim**: validação epistemológica por claim.
+2. **Comparação de versões**: mudanças entre versões de hipótese.
+3. **Glossário**: definição e relações de termo.
+4. **Perguntas em aberto**: pendências de investigação.
+5. **Auditoria de extrapolação**: análise de risco epistemológico de resposta.
+6. **Dependências de conceito**: cadeia de pré-requisitos entre conceitos.
+7. **Resumo de regime**: estado atual por recorte temático.
+
+## Contrato de entrada (query)
+
+```ts
+interface TudicoQueryInput {
+  tenantId: string; // obrigatório, origem sessão
+  query: string;
+  tool?:
+    | 'get_claim_status'
+    | 'compare_hypothesis_versions'
+    | 'fetch_glossary_term'
+    | 'list_open_questions'
+    | 'audit_response_for_extrapolation'
+    | 'map_concept_dependencies'
+    | 'summarize_regime_state';
+  payload?: Record<string, unknown>;
+}
+```
+
+## Contrato de saída (response)
+
+```ts
+interface TudicoResponse {
+  protocol: {
+    baseEstabelecida: string;
+    leituraHipoteseAtual: string;
+    auditoriaCritica: string;
+  };
+  epistemicBlocks: Array<{
+    label: 'estabelecido' | 'plausível' | 'conjectural' | 'excessivo';
+    content: string;
+  }>;
+  toolResult?: unknown;
+  warnings: string[];
+}
+```
+
+## Protocolo epistemológico obrigatório
+
+Toda resposta deve conter, na ordem:
+
+1. **Base estabelecida**
+2. **Leitura da hipótese atual**
+3. **Auditoria crítica**
+
+E classificar conteúdo nos blocos:
+
+- estabelecido
+- plausível
+- conjectural
+- excessivo
+
+## Entidades mínimas de base
+
+- `master_document`
+- `glossary`
+- `claims`
+- `hypothesis_versions`
+- `open_questions`
+- `bibliography_items`
+- `inconsistencies`

--- a/src/app/(app)/tudico/page.tsx
+++ b/src/app/(app)/tudico/page.tsx
@@ -1,0 +1,107 @@
+import { headers } from 'next/headers';
+
+import { getTudicoMemoryState } from '@/modules/tudico/memory-store';
+import { TudicoQueryPanel } from './tudico-query-panel';
+
+export const metadata = {
+  title: 'Tudico Hub — Pesquisa Estrutura Quântica-Relacional',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function TudicoPage() {
+  const headersList = await headers();
+  const tenantId = headersList.get('x-auth-tenant-id');
+
+  if (!tenantId) {
+    return <div className="p-6">Tenant não encontrado para Tudico.</div>;
+  }
+
+  const state = await getTudicoMemoryState(tenantId);
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 p-6">
+      <header className="rounded-lg border border-slate-200 bg-white p-5">
+        <h1 className="text-2xl font-semibold text-slate-900">Tudico (MVP isolado)</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Hub de pesquisa para Estrutura Quântica-Relacional. Escopo isolado de Frank e CONDSTORE operacional.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Visão geral da frente</h2>
+          <p className="mt-2 text-sm text-slate-700">{state.masterDocument.summary}</p>
+        </article>
+
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Estado MVP em Rindler</h2>
+          <p className="mt-2 text-sm text-slate-700">
+            Hipótese atual: v{state.hypothesisVersions[state.hypothesisVersions.length - 1]?.version ?? 'n/a'}.
+          </p>
+        </article>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h3 className="font-medium text-slate-900">Claims</h3>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {state.claims.map((claim) => (
+              <li key={claim.id} className="rounded border border-slate-100 p-2">
+                <strong>{claim.id}</strong>: {claim.statement} <em>({claim.status})</em>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h3 className="font-medium text-slate-900">Glossary</h3>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {state.glossary.map((term) => (
+              <li key={term.term} className="rounded border border-slate-100 p-2">
+                <strong>{term.term}</strong>: {term.definition}
+              </li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h3 className="font-medium text-slate-900">Inconsistências</h3>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {state.inconsistencies.map((item) => (
+              <li key={item.id} className="rounded border border-slate-100 p-2">
+                <strong>{item.id}</strong>: {item.description}
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h3 className="font-medium text-slate-900">Perguntas em aberto</h3>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {state.openQuestions.map((item) => (
+              <li key={item.id} className="rounded border border-slate-100 p-2">
+                <strong>{item.priority}</strong>: {item.question}
+              </li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-4">
+        <h3 className="font-medium text-slate-900">Versões da hipótese</h3>
+        <ul className="mt-3 space-y-2 text-sm text-slate-700">
+          {state.hypothesisVersions.map((version) => (
+            <li key={version.id} className="rounded border border-slate-100 p-2">
+              v{version.version} — {version.summary}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <TudicoQueryPanel />
+    </main>
+  );
+}

--- a/src/app/(app)/tudico/tudico-query-panel.tsx
+++ b/src/app/(app)/tudico/tudico-query-panel.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { TudicoToolName, TudicoResponse } from '@/modules/tudico';
+
+const TOOL_OPTIONS: TudicoToolName[] = [
+  'get_claim_status',
+  'compare_hypothesis_versions',
+  'fetch_glossary_term',
+  'list_open_questions',
+  'audit_response_for_extrapolation',
+  'map_concept_dependencies',
+  'summarize_regime_state',
+];
+
+export function TudicoQueryPanel() {
+  const [query, setQuery] = useState('Qual é o estado atual da hipótese?');
+  const [tool, setTool] = useState<TudicoToolName>('summarize_regime_state');
+  const [result, setResult] = useState<TudicoResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/tudico/query', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, tool }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(body || 'Falha ao consultar Tudico.');
+      }
+
+      const data = (await response.json()) as TudicoResponse;
+      setResult(data);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Erro inesperado.');
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="font-medium text-slate-900">Consulta epistemológica</h3>
+      <form className="mt-3 space-y-3" onSubmit={handleSubmit}>
+        <label className="block text-sm text-slate-700">
+          Consulta
+          <input
+            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </label>
+
+        <label className="block text-sm text-slate-700">
+          Tool
+          <select
+            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            value={tool}
+            onChange={(event) => setTool(event.target.value as TudicoToolName)}
+          >
+            {TOOL_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button
+          type="submit"
+          className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+          disabled={loading}
+        >
+          {loading ? 'Consultando...' : 'Executar consulta'}
+        </button>
+      </form>
+
+      {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+
+      {result ? (
+        <div className="mt-4 space-y-3 rounded border border-slate-100 bg-slate-50 p-3 text-sm">
+          <p><strong>Base estabelecida:</strong> {result.protocol.baseEstabelecida}</p>
+          <p><strong>Leitura hipótese:</strong> {result.protocol.leituraHipoteseAtual}</p>
+          <p><strong>Auditoria crítica:</strong> {result.protocol.auditoriaCritica}</p>
+          <pre className="overflow-auto rounded bg-white p-2 text-xs">{JSON.stringify(result.toolResult, null, 2)}</pre>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/api/tudico/query/route.ts
+++ b/src/app/api/tudico/query/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { requireSession } from '@/infra/auth/guards';
+import { runTudicoQuery } from '@/modules/tudico';
+import type { TudicoToolName } from '@/modules/tudico';
+
+const payloadSchema = z.object({
+  query: z.string().min(1),
+  tool: z.enum([
+    'get_claim_status',
+    'compare_hypothesis_versions',
+    'fetch_glossary_term',
+    'list_open_questions',
+    'audit_response_for_extrapolation',
+    'map_concept_dependencies',
+    'summarize_regime_state',
+  ] as [TudicoToolName, ...TudicoToolName[]]).optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const sessionResult = await requireSession(request);
+  if (!sessionResult.ok) {
+    return sessionResult.response;
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = payloadSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: 'invalid_payload',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const response = await runTudicoQuery({
+    tenantId: sessionResult.session.tenantId,
+    query: parsed.data.query,
+    tool: parsed.data.tool,
+    payload: parsed.data.payload,
+  });
+
+  return NextResponse.json(response);
+}

--- a/src/modules/tudico/__tests__/service.test.ts
+++ b/src/modules/tudico/__tests__/service.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { runTudicoQuery } from '@/modules/tudico/service';
+import { tudicoToolsRegistry } from '@/modules/tudico/tools-registry';
+
+describe('tudico tools registry', () => {
+  it('contains all mandatory tools', () => {
+    expect(Object.keys(tudicoToolsRegistry).sort()).toEqual([
+      'audit_response_for_extrapolation',
+      'compare_hypothesis_versions',
+      'fetch_glossary_term',
+      'get_claim_status',
+      'list_open_questions',
+      'map_concept_dependencies',
+      'summarize_regime_state',
+    ]);
+  });
+});
+
+describe('runTudicoQuery', () => {
+  it('returns epistemic protocol and tool result', async () => {
+    const response = await runTudicoQuery({
+      tenantId: 'tenant-test',
+      query: 'estado do regime',
+      tool: 'summarize_regime_state',
+    });
+
+    expect(response.protocol.baseEstabelecida.length).toBeGreaterThan(0);
+    expect(response.epistemicBlocks.map((block) => block.label)).toEqual([
+      'estabelecido',
+      'plausível',
+      'conjectural',
+      'excessivo',
+    ]);
+    expect(response.toolResult).toMatchObject({ currentHypothesis: '0.2' });
+  });
+});

--- a/src/modules/tudico/index.ts
+++ b/src/modules/tudico/index.ts
@@ -1,0 +1,3 @@
+export * from './service';
+export * from './types';
+export * from './tools-registry';

--- a/src/modules/tudico/master-doc-ingest.ts
+++ b/src/modules/tudico/master-doc-ingest.ts
@@ -1,0 +1,35 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { logger } from '@/infra/logger';
+import type { TudicoMasterDocument } from './types';
+
+export async function ingestMasterDocument(): Promise<TudicoMasterDocument> {
+  const sourcePath = path.join(process.cwd(), 'docs/tudico/master-document.md');
+  const startedAt = Date.now();
+
+  const raw = await readFile(sourcePath, 'utf-8');
+  const lines = raw.split('\n').map((line) => line.trim()).filter(Boolean);
+  const titleLine = lines.find((line) => line.startsWith('# ')) ?? '# Documento Mestre';
+  const title = titleLine.replace(/^#\s+/, '').trim();
+
+  const summaryStart = lines.findIndex((line) => line.toLowerCase().includes('estado base'));
+  const summary = summaryStart >= 0
+    ? lines.slice(summaryStart + 1, summaryStart + 3).join(' ').trim()
+    : lines.slice(0, 2).join(' ').trim();
+
+  const doc: TudicoMasterDocument = {
+    title,
+    summary,
+    sourcePath: 'docs/tudico/master-document.md',
+    lastIngestedAt: new Date().toISOString(),
+  };
+
+  logger.info('tudico_master_document_ingested', {
+    sourcePath: doc.sourcePath,
+    durationMs: Date.now() - startedAt,
+    title: doc.title,
+  });
+
+  return doc;
+}

--- a/src/modules/tudico/memory-store.ts
+++ b/src/modules/tudico/memory-store.ts
@@ -1,0 +1,97 @@
+import { ingestMasterDocument } from './master-doc-ingest';
+import type { TudicoMemoryState } from './types';
+
+const STORE = new Map<string, TudicoMemoryState>();
+
+function createSeedState(masterSummary: string, masterTitle: string): TudicoMemoryState {
+  return {
+    masterDocument: {
+      title: masterTitle,
+      summary: masterSummary,
+      sourcePath: 'docs/tudico/master-document.md',
+      lastIngestedAt: new Date().toISOString(),
+    },
+    claims: [
+      {
+        id: 'claim-1',
+        statement: 'Separar descrição efetiva de descrição fundamental evita colapso prematuro de modelo.',
+        status: 'plausível',
+        evidenceRefs: ['master:claims:1'],
+      },
+      {
+        id: 'claim-2',
+        statement: 'Transições de regime podem ser tratadas como mudanças de consistência entre constraints.',
+        status: 'conjectural',
+        evidenceRefs: ['master:claims:2'],
+      },
+    ],
+    glossary: [
+      {
+        term: 'Regime',
+        definition: 'Faixa de validade de uma descrição efetiva.',
+        relatedTerms: ['Constraint'],
+      },
+      {
+        term: 'Constraint',
+        definition: 'Restrição estrutural sobre relações admissíveis.',
+        relatedTerms: ['Invariância relacional'],
+      },
+    ],
+    hypothesisVersions: [
+      {
+        id: 'hyp-0.1',
+        version: '0.1',
+        summary: 'Primeira formulação da hipótese relacional.',
+        changes: ['Definição inicial de regime efetivo'],
+        createdAt: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: 'hyp-0.2',
+        version: '0.2',
+        summary: 'Introduz condicionamento por escala e contorno.',
+        changes: ['Separação explícita entre níveis efetivo/fundamental'],
+        createdAt: '2026-04-02T00:00:00.000Z',
+      },
+    ],
+    openQuestions: [
+      {
+        id: 'oq-1',
+        question: 'Quais invariantes persistem entre regimes não lineares?',
+        priority: 'high',
+      },
+      {
+        id: 'oq-2',
+        question: 'Como validar empiricamente transições entre constraints candidatas?',
+        priority: 'medium',
+      },
+    ],
+    bibliography: [
+      {
+        id: 'bib-1',
+        citation: 'Rindler Working Notes v0.2',
+        note: 'Documento base do MVP.',
+      },
+    ],
+    inconsistencies: [
+      {
+        id: 'inc-1',
+        description: 'Uso ambíguo do termo “fundamental” em notas paralelas.',
+        severity: 'medium',
+        relatedClaimIds: ['claim-1'],
+        action: 'Padronizar definição no glossary e revisar claims relacionados.',
+      },
+    ],
+  };
+}
+
+export async function getTudicoMemoryState(tenantId: string): Promise<TudicoMemoryState> {
+  const existing = STORE.get(tenantId);
+  if (existing) return existing;
+
+  const ingested = await ingestMasterDocument();
+  const seed = createSeedState(ingested.summary, ingested.title);
+  seed.masterDocument = ingested;
+
+  STORE.set(tenantId, seed);
+  return seed;
+}

--- a/src/modules/tudico/response-protocol.ts
+++ b/src/modules/tudico/response-protocol.ts
@@ -1,0 +1,45 @@
+import type { TudicoMemoryState, TudicoResponse } from './types';
+
+export function buildTudicoResponse(params: {
+  state: TudicoMemoryState;
+  query: string;
+  toolResult?: unknown;
+  warnings?: string[];
+}): TudicoResponse {
+  const latestHypothesis = params.state.hypothesisVersions[params.state.hypothesisVersions.length - 1];
+  const inconsistentCount = params.state.inconsistencies.length;
+
+  const protocol = {
+    baseEstabelecida: params.state.masterDocument.summary,
+    leituraHipoteseAtual: latestHypothesis
+      ? `v${latestHypothesis.version}: ${latestHypothesis.summary}`
+      : 'Sem hipótese registrada.',
+    auditoriaCritica: inconsistentCount > 0
+      ? `${inconsistentCount} inconsistência(s) ativas exigem revisão antes de concluir causalidade.`
+      : 'Sem inconsistências abertas no recorte atual.',
+  };
+
+  return {
+    protocol,
+    epistemicBlocks: [
+      {
+        label: 'estabelecido',
+        content: protocol.baseEstabelecida,
+      },
+      {
+        label: 'plausível',
+        content: `Consulta recebida: ${params.query}`,
+      },
+      {
+        label: 'conjectural',
+        content: 'Interpretações novas devem ser tratadas como hipótese até validação adicional.',
+      },
+      {
+        label: 'excessivo',
+        content: 'Evitar extrapolar para unificação total sem evidência explícita no corpus.',
+      },
+    ],
+    toolResult: params.toolResult,
+    warnings: params.warnings ?? [],
+  };
+}

--- a/src/modules/tudico/service.ts
+++ b/src/modules/tudico/service.ts
@@ -1,0 +1,36 @@
+import { logger } from '@/infra/logger';
+import { getTudicoMemoryState } from './memory-store';
+import { buildTudicoResponse } from './response-protocol';
+import { tudicoToolsRegistry } from './tools-registry';
+import type { TudicoQueryInput, TudicoResponse } from './types';
+
+export async function runTudicoQuery(input: TudicoQueryInput): Promise<TudicoResponse> {
+  const startedAt = Date.now();
+  const state = await getTudicoMemoryState(input.tenantId);
+
+  const warnings: string[] = [];
+  let toolResult: unknown;
+
+  if (input.tool) {
+    const tool = tudicoToolsRegistry[input.tool];
+    toolResult = tool(state, input.payload);
+  } else {
+    warnings.push('Nenhuma tool específica selecionada; retorno baseado no protocolo padrão.');
+  }
+
+  const response = buildTudicoResponse({
+    state,
+    query: input.query,
+    toolResult,
+    warnings,
+  });
+
+  logger.info('tudico_query_processed', {
+    tenantId: input.tenantId,
+    tool: input.tool ?? 'none',
+    durationMs: Date.now() - startedAt,
+    warnings: response.warnings.length,
+  });
+
+  return response;
+}

--- a/src/modules/tudico/tools-registry.ts
+++ b/src/modules/tudico/tools-registry.ts
@@ -1,0 +1,85 @@
+import type { TudicoMemoryState, TudicoToolName } from './types';
+
+export type TudicoTool = (state: TudicoMemoryState, payload?: Record<string, unknown>) => unknown;
+
+function getClaimStatus(state: TudicoMemoryState, payload?: Record<string, unknown>) {
+  const claimId = typeof payload?.claimId === 'string' ? payload.claimId : null;
+  if (!claimId) return state.claims;
+  return state.claims.find((claim) => claim.id === claimId) ?? null;
+}
+
+function compareHypothesisVersions(state: TudicoMemoryState, payload?: Record<string, unknown>) {
+  const fromVersion = typeof payload?.fromVersion === 'string' ? payload.fromVersion : state.hypothesisVersions[0]?.version;
+  const toVersion = typeof payload?.toVersion === 'string' ? payload.toVersion : state.hypothesisVersions[state.hypothesisVersions.length - 1]?.version;
+
+  const from = state.hypothesisVersions.find((item) => item.version === fromVersion);
+  const to = state.hypothesisVersions.find((item) => item.version === toVersion);
+
+  if (!from || !to) {
+    return { fromVersion, toVersion, found: false };
+  }
+
+  const added = to.changes.filter((change) => !from.changes.includes(change));
+  const removed = from.changes.filter((change) => !to.changes.includes(change));
+
+  return {
+    fromVersion: from.version,
+    toVersion: to.version,
+    added,
+    removed,
+    found: true,
+  };
+}
+
+function fetchGlossaryTerm(state: TudicoMemoryState, payload?: Record<string, unknown>) {
+  const term = typeof payload?.term === 'string' ? payload.term.toLowerCase() : '';
+  return state.glossary.find((item) => item.term.toLowerCase() === term) ?? null;
+}
+
+function listOpenQuestions(state: TudicoMemoryState) {
+  return state.openQuestions;
+}
+
+function auditResponseForExtrapolation(_: TudicoMemoryState, payload?: Record<string, unknown>) {
+  const text = typeof payload?.text === 'string' ? payload.text : '';
+  const riskMarkers = ['sempre', 'prova definitiva', 'garante', 'sem exceção'];
+  const found = riskMarkers.filter((marker) => text.toLowerCase().includes(marker));
+
+  return {
+    riskLevel: found.length > 0 ? 'high' : 'low',
+    markers: found,
+    recommendation: found.length > 0
+      ? 'Reduzir afirmações absolutas e classificar bloco como conjectural/excessivo quando aplicável.'
+      : 'Sem extrapolação forte detectada por heurística mínima.',
+  };
+}
+
+function mapConceptDependencies(state: TudicoMemoryState, payload?: Record<string, unknown>) {
+  const term = typeof payload?.term === 'string' ? payload.term.toLowerCase() : '';
+  const node = state.glossary.find((item) => item.term.toLowerCase() === term);
+  if (!node) return { term: payload?.term ?? null, dependencies: [] };
+
+  return {
+    term: node.term,
+    dependencies: node.relatedTerms,
+  };
+}
+
+function summarizeRegimeState(state: TudicoMemoryState) {
+  return {
+    claims: state.claims.length,
+    openQuestions: state.openQuestions.length,
+    inconsistencies: state.inconsistencies.length,
+    currentHypothesis: state.hypothesisVersions[state.hypothesisVersions.length - 1]?.version ?? 'n/a',
+  };
+}
+
+export const tudicoToolsRegistry: Record<TudicoToolName, TudicoTool> = {
+  get_claim_status: getClaimStatus,
+  compare_hypothesis_versions: compareHypothesisVersions,
+  fetch_glossary_term: fetchGlossaryTerm,
+  list_open_questions: listOpenQuestions,
+  audit_response_for_extrapolation: auditResponseForExtrapolation,
+  map_concept_dependencies: mapConceptDependencies,
+  summarize_regime_state: summarizeRegimeState,
+};

--- a/src/modules/tudico/types.ts
+++ b/src/modules/tudico/types.ts
@@ -1,0 +1,92 @@
+export type TudicoEpistemicLabel = 'estabelecido' | 'plausível' | 'conjectural' | 'excessivo';
+
+export interface TudicoMasterDocument {
+  title: string;
+  summary: string;
+  sourcePath: string;
+  lastIngestedAt: string;
+}
+
+export interface TudicoGlossaryTerm {
+  term: string;
+  definition: string;
+  relatedTerms: string[];
+}
+
+export interface TudicoClaim {
+  id: string;
+  statement: string;
+  status: TudicoEpistemicLabel;
+  evidenceRefs: string[];
+  notes?: string;
+}
+
+export interface TudicoHypothesisVersion {
+  id: string;
+  version: string;
+  summary: string;
+  changes: string[];
+  createdAt: string;
+}
+
+export interface TudicoOpenQuestion {
+  id: string;
+  question: string;
+  priority: 'low' | 'medium' | 'high';
+}
+
+export interface TudicoBibliographyItem {
+  id: string;
+  citation: string;
+  note?: string;
+}
+
+export interface TudicoInconsistency {
+  id: string;
+  description: string;
+  severity: 'low' | 'medium' | 'high';
+  relatedClaimIds: string[];
+  action: string;
+}
+
+export interface TudicoMemoryState {
+  masterDocument: TudicoMasterDocument;
+  glossary: TudicoGlossaryTerm[];
+  claims: TudicoClaim[];
+  hypothesisVersions: TudicoHypothesisVersion[];
+  openQuestions: TudicoOpenQuestion[];
+  bibliography: TudicoBibliographyItem[];
+  inconsistencies: TudicoInconsistency[];
+}
+
+export type TudicoToolName =
+  | 'get_claim_status'
+  | 'compare_hypothesis_versions'
+  | 'fetch_glossary_term'
+  | 'list_open_questions'
+  | 'audit_response_for_extrapolation'
+  | 'map_concept_dependencies'
+  | 'summarize_regime_state';
+
+export interface TudicoQueryInput {
+  tenantId: string;
+  query: string;
+  tool?: TudicoToolName;
+  payload?: Record<string, unknown>;
+}
+
+export interface TudicoEpistemicBlock {
+  label: TudicoEpistemicLabel;
+  content: string;
+}
+
+export interface TudicoResponse {
+  protocol: {
+    baseEstabelecida: string;
+    leituraHipoteseAtual: string;
+    auditoriaCritica: string;
+  };
+  epistemicBlocks: TudicoEpistemicBlock[];
+  toolResult?: unknown;
+  warnings: string[];
+}


### PR DESCRIPTION
### Motivation

- Implement a minimal, isolated research agent (Tudico) for the Estrutura Quântica-Relacional front following the SDD flow (Spec → Design → Dev) to provide a tenant-scoped memory/context layer, tools registry and epistemological response protocol without touching Frank/runtime or operational CONDSTORE flows. 
- Keep scope small and safe for MVP: in-memory tenant-scoped store, server-side hub, a guarded API and documentation (spec + design + master document) so the feature is discoverable and auditable.

### Description

- Added a new Tudico domain at `src/modules/tudico/**` implementing types, in-memory `TudicoMemoryState`, master-document ingestion, a 7-tool `tudicoToolsRegistry`, a `runTudicoQuery` service and an epistemological `buildTudicoResponse` protocol. 
- Exposed a tenant-scoped API `POST /api/tudico/query` implemented at `src/app/api/tudico/query/route.ts` secured with `requireSession` and deriving `tenantId` from the session (never trusting body/query). 
- Added a server-route hub and client query panel at `src/app/(app)/tudico/page.tsx` and `tudico-query-panel.tsx` to browse master document, claims, glossary, inconsistencies, hypothesis versions and run tool-backed queries. 
- Added SDD documentation and seed: `docs/tudico/spec.md`, `docs/tudico/design.md`, `docs/tudico/master-document.md`, and updated `README.md`, `ARCHITECTURE.md`, `docs/routes-registry.md` and generated routes inventory to include the new surface. 
- Added unit tests under `src/modules/tudico/__tests__/service.test.ts` validating the tools registry and the service execution path, and instrumented structured logs (`tudico_master_document_ingested`, `tudico_query_processed`).

### Testing

- `npm run lint` — passed. 
- `npm run typecheck` — passed. 
- `npm run routes:verify-security` — initially flagged the new route as missing guards; the API was updated to use `requireSession` and the check then passed. 
- `npm run routes:sync` — updated registry/inventory to include `/tudico` and `/api/tudico/query` and verification passed. 
- Unit tests: `npm run test:win-stable -- src/modules/tudico/__tests__/service.test.ts` (Vitest) — passed. 
- `npm run build` (Next.js production build) — passed. 
- Note: `npm run guardrail:mvp-freeze` and `npm run scope:pr-tests` initially failed in this environment because `origin/main` was not available in the workspace; the guardrail was executed using `MVP_FREEZE_BASE=HEAD` and `scope:pr-tests` was run with explicit `--files` and both validations completed successfully for the files in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce1666e77883318bc168f8b2803fec)