### PR TITLE
feat: auditar decisões humanas no ciclo de sugestão

### DIFF
--- a/src/modules/audit/operational-audit.service.ts
+++ b/src/modules/audit/operational-audit.service.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import { eq, and, asc, desc } from 'drizzle-orm';
 import { logger } from '@/infra/logger';
 
-export type OperationalEntityType = 'opportunity' | 'order' | 'client' | 'conversation' | 'shipment';
+export type OperationalEntityType = 'opportunity' | 'order' | 'client' | 'conversation' | 'shipment' | 'suggestion';
 export type ActionOrigin = 'ui' | 'bulk' | 'drawer' | 'palette' | 'frank' | 'system';
 
 export interface LogOperationalActivityParams {

--- a/src/modules/frank/suggestions/__tests__/suggestion.service.test.ts
+++ b/src/modules/frank/suggestions/__tests__/suggestion.service.test.ts
@@ -4,6 +4,7 @@ const mockCreate = vi.hoisted(() => vi.fn());
 const mockFindById = vi.hoisted(() => vi.fn());
 const mockUpdateStatus = vi.hoisted(() => vi.fn());
 const mockListPending = vi.hoisted(() => vi.fn());
+const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/events/operational-event-bus', () => ({
     publishOperationalEvent: vi.fn().mockResolvedValue(undefined)
@@ -18,11 +19,18 @@ vi.mock('../suggestion.repository', () => ({
     }
 }));
 
+vi.mock('@/modules/audit/operational-audit.service', () => ({
+    operationalAuditService: {
+        logActivity: mockLogActivity,
+    },
+}));
+
 import { suggestionService } from '../suggestion.service';
 
 describe('SuggestionService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockLogActivity.mockResolvedValue(undefined);
     });
 
     it('generateSuggestion should create and emit event', async () => {
@@ -54,6 +62,13 @@ describe('SuggestionService', () => {
 
         expect(ok).toBe(true);
         expect(mockUpdateStatus).toHaveBeenCalledWith('tenant-1', 'sugg-1', 'approved', 'op-1', 'Original');
+        expect(mockLogActivity).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-1',
+            entityType: 'suggestion',
+            entityId: 'sugg-1',
+            actorId: 'op-1',
+            actionType: 'suggestion_approved',
+        }));
     });
 
     it('approveSuggestion should update status and emit edited event', async () => {
@@ -71,6 +86,13 @@ describe('SuggestionService', () => {
 
         expect(ok).toBe(true);
         expect(mockUpdateStatus).toHaveBeenCalledWith('tenant-1', 'sugg-2', 'edited', 'op-1', 'Edited');
+        expect(mockLogActivity).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-1',
+            entityType: 'suggestion',
+            entityId: 'sugg-2',
+            actorId: 'op-1',
+            actionType: 'suggestion_edited',
+        }));
     });
 
     it('rejectSuggestion should update status to rejected', async () => {
@@ -84,5 +106,12 @@ describe('SuggestionService', () => {
 
         expect(ok).toBe(true);
         expect(mockUpdateStatus).toHaveBeenCalledWith('tenant-1', 'sugg-3', 'rejected', 'op-1');
+        expect(mockLogActivity).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-1',
+            entityType: 'suggestion',
+            entityId: 'sugg-3',
+            actorId: 'op-1',
+            actionType: 'suggestion_rejected',
+        }));
     });
 });

--- a/src/modules/frank/suggestions/suggestion.service.ts
+++ b/src/modules/frank/suggestions/suggestion.service.ts
@@ -5,8 +5,9 @@ import {
     emitSuggestionEdited,
     emitSuggestionRejected
 } from './suggestion.events';
-import { CreateSuggestionDTO, ApproveSuggestionDTO, FrankSuggestion } from './suggestion.types';
+import { CreateSuggestionDTO, ApproveSuggestionDTO } from './suggestion.types';
 import { logger } from '@/infra/logger';
+import { operationalAuditService } from '@/modules/audit/operational-audit.service';
 
 export class SuggestionService {
     async generateSuggestion(tenantId: string, sessionId: string, dto: CreateSuggestionDTO): Promise<string> {
@@ -62,6 +63,30 @@ export class SuggestionService {
             };
 
             logger.info(`frank_suggestion_${status}`, payload);
+            await operationalAuditService.logActivity({
+                tenantId,
+                entityType: 'suggestion',
+                entityId: id,
+                actorId: dto.operatorId,
+                actionType: `suggestion_${status}`,
+                beforeState: {
+                    status: existing.status,
+                    suggestedResponse: existing.suggestedResponse,
+                },
+                afterState: {
+                    status,
+                    suggestedResponse: dto.finalResponse ?? existing.suggestedResponse,
+                },
+                origin: 'frank',
+                metadata: {
+                    conversationId: existing.conversationId,
+                    sessionId: existing.sessionId,
+                    intent: existing.intent,
+                    decisionContext: {
+                        edited: isEdited,
+                    },
+                },
+            });
             if (isEdited) emitSuggestionEdited(tenantId, payload);
             else emitSuggestionApproved(tenantId, payload);
         }
@@ -87,6 +112,30 @@ export class SuggestionService {
                 rejectedBy: operatorId
             };
             logger.info('frank_suggestion_rejected', payload);
+            await operationalAuditService.logActivity({
+                tenantId,
+                entityType: 'suggestion',
+                entityId: id,
+                actorId: operatorId,
+                actionType: 'suggestion_rejected',
+                beforeState: {
+                    status: existing.status,
+                    suggestedResponse: existing.suggestedResponse,
+                },
+                afterState: {
+                    status: 'rejected',
+                    suggestedResponse: existing.suggestedResponse,
+                },
+                origin: 'frank',
+                metadata: {
+                    conversationId: existing.conversationId,
+                    sessionId: existing.sessionId,
+                    intent: existing.intent,
+                    decisionContext: {
+                        rejected: true,
+                    },
+                },
+            });
             emitSuggestionRejected(tenantId, payload);
         }
 


### PR DESCRIPTION
### Motivation
- Garantir rastreabilidade das decisões humanas no fluxo de sugestões (approve / edit / reject) sem alterar o comportamento atual.
- Incluir operador responsável e contexto das decisões para observabilidade e investigação operacional.
- Manter tipagem forte e reuso do serviço de auditoria existente para consistência multi-tenant.

### Description
- Adiciona chamadas a `operationalAuditService.logActivity` em `SuggestionService` para os caminhos `approved`, `edited` e `rejected`, incluindo `beforeState`, `afterState`, `actorId`, `origin` e `metadata` com `conversationId`, `sessionId` e `intent`.
- Expande o tipo `OperationalEntityType` com a opção `suggestion` em `operational-audit.service.ts` para tipagem consistente.
- Atualiza os testes unitários de `suggestion.service` para mockar `operationalAuditService.logActivity` e validar que logs de auditoria são emitidos em cada caminho de decisão.
- Não altera a lógica de decisão nem o fluxo funcional; apenas registra auditoria adicional.

### Testing
- Executed `npm run scope:pr-tests -- --files src/modules/frank/suggestions/suggestion.service.ts src/modules/audit/operational-audit.service.ts src/modules/frank/suggestions/__tests__/suggestion.service.test.ts` to determine test scope (completed).
- Attempted `npm run guardrail:mvp-freeze` but the script failed in this environment due to missing `origin/main` diff base (environment limitation).
- Ran unit tests for suggestions with `npx vitest run --configLoader runner --config vitest.config.mjs src/modules/frank/suggestions/__tests__/suggestion.service.test.ts` and all tests passed.
- Ran broader suite `npm run test:mvp` and the targeted MVP test groups completed successfully in CI-run (tests passed for whatsapp/cockpit/freight groups where applicable).
- Ran `npm run lint` and `npm run typecheck` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce16aa35a0833191649cf6cce57c80)