### PR TITLE
MPV-28: standardize Frank telemetry and propagate requestId end-to-end

### DIFF
--- a/src/modules/frank/agent-loop.ts
+++ b/src/modules/frank/agent-loop.ts
@@ -1,4 +1,4 @@
-import { logger } from '@/infra/logger';
+import { structuredLogger } from '@/infra/log/logger';
 
 export type ToolResult = {
     ok: boolean;
@@ -119,7 +119,7 @@ export async function runFrankAgentTool(params: {
             },
         };
 
-        logger.info('frank_agent_loop_execution', {
+        structuredLogger.info('frank_agent_loop_execution', {
             requestId: params.requestId,
             action: plannedAction,
             outcome: blockedResult.status,
@@ -148,7 +148,7 @@ export async function runFrankAgentTool(params: {
             },
         };
 
-        logger.info('frank_agent_loop_execution', {
+        structuredLogger.info('frank_agent_loop_execution', {
             requestId: params.requestId,
             action: plannedAction,
             outcome: success.status,
@@ -171,11 +171,13 @@ export async function runFrankAgentTool(params: {
             },
         };
 
-        logger.info('frank_agent_loop_execution', {
+        structuredLogger.warn('frank_agent_loop_execution', {
             requestId: params.requestId,
             action: plannedAction,
             outcome: failed.status,
             durationMs: Date.now() - start,
+            errorCode: failed.errorCode,
+            errorMessage: message,
         });
 
         return failed;

--- a/src/modules/frank/tools/tool-policy.ts
+++ b/src/modules/frank/tools/tool-policy.ts
@@ -1,4 +1,4 @@
-import { logger } from '@/infra/logger';
+import { structuredLogger } from '@/infra/log/logger';
 
 export type FrankToolAction =
     | 'freight_calculation'
@@ -30,7 +30,7 @@ export function evaluateFrankToolPolicy(
     const riskLevel: FrankToolRiskLevel = HIGH_RISK_ACTIONS.has(action) ? 'HIGH_RISK' : 'LOW_RISK';
 
     if (riskLevel === 'HIGH_RISK' && !context.allowHighRisk) {
-        logger.warn('frank_tool_policy_blocked', {
+        structuredLogger.warn('frank_tool_policy_blocked', {
             tenantId: context.tenantId,
             requestId: context.requestId,
             action,

--- a/src/modules/frank/tools/tool-runner.ts
+++ b/src/modules/frank/tools/tool-runner.ts
@@ -1,5 +1,5 @@
 import { freightService } from '@/modules/freight/freight.service';
-import { logger } from '@/infra/logger';
+import { structuredLogger } from '@/infra/log/logger';
 import { createOrderFromQuoteTool, type CreateOrderFromQuoteParams } from './create-order-from-quote.tool';
 import { getOrderStatusTool, type GetOrderStatusParams, type OrderStatusResult } from './read-only/getOrderStatus.tool';
 import { getShipmentStatusTool, type GetShipmentStatusParams, type ShipmentStatusResult } from './read-only/getShipmentStatus.tool';
@@ -94,7 +94,7 @@ export async function runTool<TAction extends FrankToolAction>(
             },
         };
 
-        logger.warn('frank_tool_runner_completed', {
+        structuredLogger.warn('frank_tool_runner_completed', {
             tenantId: context.tenantId,
             requestId: context.requestId,
             action,
@@ -110,7 +110,7 @@ export async function runTool<TAction extends FrankToolAction>(
         const data = await executeToolAction(action, input);
         const durationMs = Date.now() - startedAt;
 
-        logger.info('frank_tool_runner_completed', {
+        structuredLogger.info('frank_tool_runner_completed', {
             tenantId: context.tenantId,
             requestId: context.requestId,
             action,
@@ -132,12 +132,13 @@ export async function runTool<TAction extends FrankToolAction>(
         const durationMs = Date.now() - startedAt;
         const message = error instanceof Error ? error.message : 'Unknown tool execution error';
 
-        logger.error('frank_tool_runner_failed', error as Error, {
+        structuredLogger.error('frank_tool_runner_failed', {
             tenantId: context.tenantId,
             requestId: context.requestId,
             action,
             input: sanitizeTelemetryInput(input),
             durationMs,
+            error,
         });
 
         return {

--- a/src/modules/frank/whatsapp-orchestrator.ts
+++ b/src/modules/frank/whatsapp-orchestrator.ts
@@ -37,6 +37,7 @@ import { getDb } from '@/infra/db';
 import { carrierPolicies, customers, customerTimelineEvents } from '@/drizzle/schema';
 import { eq, and } from 'drizzle-orm';
 import { logger } from '@/infra/logger';
+import { structuredLogger } from '@/infra/log/logger';
 import { publishOperationalEvent } from '@/lib/events/operational-event-bus';
 import { twilioProvider } from '@/providers/twilio.provider';
 import { catalogService } from '@/modules/catalog/catalog.service';
@@ -246,6 +247,7 @@ function buildAssistantResult(params: {
 
 async function finalizeAssistantResponse(params: {
     tenantId: string;
+    requestId: string;
     reply: string;
     intentResult: IntentResult;
     context: ConversationContext | null;
@@ -283,6 +285,7 @@ async function finalizeAssistantResponse(params: {
 
     logger.info('frank_assist_response', {
         tenantId: params.tenantId,
+        requestId: params.requestId,
         ...responsePayload,
         missingContextReason: params.outcome === 'fallback' ? params.fallbackReason : undefined,
         customerId: params.customerId ?? undefined,
@@ -298,7 +301,10 @@ async function finalizeAssistantResponse(params: {
         entityId,
         customerId: params.customerId ?? null,
         sessionId,
-        payload: responsePayload,
+        payload: {
+            ...responsePayload,
+            requestId: params.requestId,
+        },
     });
 
     if (params.outcome === 'fallback') {
@@ -306,6 +312,7 @@ async function finalizeAssistantResponse(params: {
 
         logger.warn('frank_assist_handoff', {
             tenantId: params.tenantId,
+            requestId: params.requestId,
             intent: params.intentResult.intent,
             reason: handoffReason,
             toolUsed,
@@ -326,6 +333,7 @@ async function finalizeAssistantResponse(params: {
                 intent: params.intentResult.intent,
                 toolUsed,
                 reason: handoffReason,
+                requestId: params.requestId,
             },
         });
     }
@@ -457,6 +465,7 @@ function formatRecentQuotesReply(recentQuotes: RecentQuoteSummary[]): string {
 
 async function handleAssistantIntent(params: {
     tenantId: string;
+    requestId: string;
     message: string;
     phone?: string;
     intentResult: IntentResult;
@@ -465,14 +474,14 @@ async function handleAssistantIntent(params: {
     productRef: string | null;
     extractedEntities?: ExtractedEntities;
 }): Promise<OrchestratorResult> {
-    const { tenantId, message, phone, intentResult, context, cep, productRef, extractedEntities } = params;
+    const { tenantId, requestId, message, phone, intentResult, context, cep, productRef, extractedEntities } = params;
     const startedAt = Date.now();
     const explicitId = extractUuidLikeId(message) ?? extractedEntities?.orderId ?? null;
-    const requestId = crypto.randomUUID();
 
     if (isLowConfidenceAssistantIntent(intentResult)) {
         return finalizeAssistantResponse({
             tenantId,
+            requestId,
             reply: formatSupportResponse({
                 answer: 'Não consegui classificar essa solicitação com segurança.',
                 nextStep: ASSISTANT_REPHRASE_GUIDANCE,
@@ -494,6 +503,7 @@ async function handleAssistantIntent(params: {
         case 'PRODUTO':
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: formatSupportResponse({
                     answer: 'Estou em modo assistente com leitura estrita.',
                     facts: ['Neste momento eu só consulto dados de pedido, envio, cotação e contexto do cliente.'],
@@ -542,6 +552,7 @@ async function handleAssistantIntent(params: {
                 if (!customerId) {
                     return finalizeAssistantResponse({
                         tenantId,
+                        requestId,
                         reply: formatSupportResponse({
                             answer: 'Não consegui localizar o cliente desta conversa com segurança.',
                             nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -567,6 +578,7 @@ async function handleAssistantIntent(params: {
                 if (recentOrders.length === 0) {
                     return finalizeAssistantResponse({
                         tenantId,
+                        requestId,
                         reply: formatSupportResponse({
                             answer: 'Não encontrei pedido para este cliente.',
                             nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -594,6 +606,7 @@ async function handleAssistantIntent(params: {
             if (!orderStatus) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não encontrei esse pedido com segurança.',
                         nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -613,6 +626,7 @@ async function handleAssistantIntent(params: {
 
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: formatOrderStatusReply(orderStatus, {
                     assumedMostRecent,
                     nextStep: orderStatus.linkedShipment
@@ -663,6 +677,7 @@ async function handleAssistantIntent(params: {
                     if (!customerId) {
                         return finalizeAssistantResponse({
                             tenantId,
+                            requestId,
                             reply: formatSupportResponse({
                                 answer: 'Não consegui localizar o cliente desta conversa com segurança.',
                                 nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -687,6 +702,7 @@ async function handleAssistantIntent(params: {
                     if (recentOrders.length === 0) {
                         return finalizeAssistantResponse({
                             tenantId,
+                            requestId,
                             reply: formatSupportResponse({
                                 answer: 'Não encontrei envio para este cliente.',
                                 nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -716,6 +732,7 @@ async function handleAssistantIntent(params: {
                 if (!partialOrderStatus?.linkedShipment) {
                     return finalizeAssistantResponse({
                         tenantId,
+                        requestId,
                         reply: formatSupportResponse({
                             answer: partialOrderStatus
                                 ? `Encontrei o pedido ${partialOrderStatus.order.id}, mas o envio ainda não está disponível para consulta.`
@@ -748,6 +765,7 @@ async function handleAssistantIntent(params: {
             if (!shipmentStatus) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não encontrei esse envio com segurança.',
                         nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -775,6 +793,7 @@ async function handleAssistantIntent(params: {
 
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: shipmentReply,
                 intentResult,
                 context,
@@ -797,6 +816,7 @@ async function handleAssistantIntent(params: {
             if (!customerId) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não consegui localizar o cliente desta conversa com segurança.',
                         nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -820,6 +840,7 @@ async function handleAssistantIntent(params: {
             if (recentOrders.length === 0) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não encontrei pedidos recentes para este cliente.',
                         nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -838,6 +859,7 @@ async function handleAssistantIntent(params: {
 
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: formatRecentOrdersReply(recentOrders),
                 intentResult,
                 context,
@@ -858,6 +880,7 @@ async function handleAssistantIntent(params: {
             if (!customerId) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não consegui localizar o cliente desta conversa com segurança.',
                         nextStep: ASSISTANT_QUOTE_GUIDANCE,
@@ -881,6 +904,7 @@ async function handleAssistantIntent(params: {
             if (recentQuotes.length === 0) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não encontrei cotações recentes para este cliente.',
                         nextStep: ASSISTANT_QUOTE_GUIDANCE,
@@ -899,6 +923,7 @@ async function handleAssistantIntent(params: {
 
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: formatRecentQuotesReply(recentQuotes),
                 intentResult,
                 context,
@@ -923,6 +948,7 @@ async function handleAssistantIntent(params: {
             if (!customerContext) {
                 return finalizeAssistantResponse({
                     tenantId,
+                    requestId,
                     reply: formatSupportResponse({
                         answer: 'Não encontrei contexto suficiente para esse cliente.',
                         nextStep: ASSISTANT_HUMAN_GUIDANCE,
@@ -950,6 +976,7 @@ async function handleAssistantIntent(params: {
 
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: formatSupportResponse({
                     answer: `Encontrei o cadastro vinculado à organização ${organizationName}.`,
                     facts: [
@@ -981,6 +1008,7 @@ async function handleAssistantIntent(params: {
         default:
             return finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: formatSupportResponse({
                     answer: 'Não consegui resolver essa consulta com segurança.',
                     nextStep: ASSISTANT_REPHRASE_GUIDANCE,
@@ -1003,7 +1031,10 @@ export async function handleIncomingMessage(
     tenantId: string,
     message: string,
     phone?: string,
+    options?: { requestId?: string },
 ): Promise<OrchestratorResult> {
+    const requestId = options?.requestId ?? crypto.randomUUID();
+    structuredLogger.info('frank_orchestrator_start', { tenantId, requestId, eventType: 'orchestrator_start' });
     const assistantMode = isFrankAssistantMode();
     const cep = extractCep(message);
     const cepRaw = extractCepRaw(message);
@@ -1510,6 +1541,7 @@ export async function handleIncomingMessage(
             const finalReply = `${playbook.responseBase}\n\n${playbook.nextStepSuggestion ?? ''}`.trim();
             const assistantResult = await finalizeAssistantResponse({
                 tenantId,
+                requestId,
                 reply: finalReply,
                 intentResult,
                 context,
@@ -1529,6 +1561,7 @@ export async function handleIncomingMessage(
 
         const assistantResult = await handleAssistantIntent({
             tenantId,
+            requestId,
             message,
             phone,
             intentResult,
@@ -1605,6 +1638,13 @@ export async function handleIncomingMessage(
         }).catch(() => {});
     }
 
+    structuredLogger.info('frank_orchestrator_end', {
+        tenantId,
+        requestId,
+        intent: intentResult.intent,
+        confidence: intentResult.confidence,
+        eventType: 'orchestrator_end',
+    });
     return genericResult;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure Frank telemetry is consistent and correlatable end-to-end by standardizing on the structured logger and a single request-scoped `requestId` for assistant flows. 
- Make assistant responses and handoffs auditable and ready for future Cockpit integration by including `requestId` in operational events. 
- Reduce troubleshooting friction by adding explicit orchestrator start/end traces for full-path correlation. 

### Description
- Replaced ad-hoc `logger` calls with the structured logger (`structuredLogger`) in `src/modules/frank/agent-loop.ts`, `src/modules/frank/tools/tool-policy.ts` and `src/modules/frank/tools/tool-runner.ts` to emit consistent structured events. 
- Propagated a single `requestId` through the assistant path by changing `handleIncomingMessage` to accept/derive `requestId` and passing it into `handleAssistantIntent` and `finalizeAssistantResponse`. 
- Included `requestId` inside `frank_assist_response` and `frank_assist_handoff` operational event payloads and added `frank_orchestrator_start` / `frank_orchestrator_end` structured logs for trace boundaries. 
- Kept existing telemetry hygiene (input sanitization) and added error fields to failure logs to improve observability without exposing PII. 

### Testing
- Ran scoped PR tests with `node scripts/pr-test-scope.mjs --files ...` which identified the guardrail action and suggested `npm run guardrail:mvp-freeze`; that check is required but `npm run guardrail:mvp-freeze` failed in this environment due to missing remote `origin/main` (env limitation). 
- Executed unit tests for the modified Frank areas with `vitest` (`src/modules/frank/__tests__/agent-loop.test.ts`, `src/modules/frank/tools/tool-runner.test.ts`, `src/modules/frank/whatsapp-orchestrator.test.ts`) and they passed. 
- Ran the WhatsApp test suite `npm run test:whatsapp` and the suite passed. 
- Ran `npm run lint` and `npm run typecheck` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce185e3c608331bf5c621c6fff20fb)