### PR TITLE
feat(frank): separate planner responsibilities into sub-agents

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,6 +122,7 @@ Controles observáveis no código:
 - Modo supervisionado suportado (`SUPERVISED_ONLY`) para geração de sugestão sem envio autônomo indiscriminado.
 - Tool model com guard de execução (`src/modules/frank/tools/tool-guard.ts`).
 - Agent loop mínimo para ações operacionais críticas: `src/modules/frank/agent-loop.ts` (planner + policy + memory + telemetry), integrado de forma compatível no fluxo `Quote -> Order`.
+- Separação de sub-agentes no loop Frank: o planner classifica ação por domínio (`ATENDIMENTO`, `CRM`, `FREIGHT`, `LOGISTICA`) e registra handoff explícito para troubleshooting e governança operacional.
 
 ## 8) Segurança e invariantes arquiteturais
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Para demos/pilotos reproduzíveis, use o runbook em [`docs/demo/demo-tenant-runb
 - **Pedidos e logística**: criação/consulta de pedidos, shipment service/repository e integração com dados de frete.
 - **Frank (IA) com governança**: orquestrador, sugestões supervisionadas, tools, memória, intent linker e gateway de provider centralizado.
 - **Frank agent loop (base mínima)**: camada incremental com planner/policy/tool contract (`ToolResult`), memória operacional básica e telemetria estruturada no fluxo de conversão de cotação aprovada para pedido.
+- **Frank sub-agent separation (MVP)**: planner com responsabilidade explícita por sub-agente (`ATENDIMENTO`, `CRM`, `FREIGHT`, `LOGISTICA`) e handoff rastreável em auditoria/log para reduzir acoplamento entre domínios.
 - **Eventos operacionais e DOMINE**: publicação de eventos com sanitização de PII, processamento assíncrono com DLQ e trilha de auditoria.
 
 ## Stack real

--- a/src/modules/frank/__tests__/agent-loop.test.ts
+++ b/src/modules/frank/__tests__/agent-loop.test.ts
@@ -14,6 +14,8 @@ describe('Frank agent loop (minimal)', () => {
         expect(result.status).toBe('BLOCKED_BY_POLICY');
         expect(result.errorCode).toBe('POLICY_BLOCKED');
         expect(result.errorMessage).toContain('cotacao precisa estar aprovada');
+        expect(result.audit?.subAgent).toBe('FREIGHT');
+        expect(result.audit?.handoff).toContain('precondição');
     });
 
     it('executes LOW_RISK action successfully', async () => {
@@ -27,6 +29,7 @@ describe('Frank agent loop (minimal)', () => {
         expect(result.ok).toBe(true);
         expect(result.status).toBe('EXECUTED');
         expect(result.data).toEqual({ quoteId: 'q-1' });
+        expect(result.audit?.subAgent).toBe('FREIGHT');
     });
 
     it('always returns ToolResult shape on execution failure', async () => {

--- a/src/modules/frank/agent-loop.ts
+++ b/src/modules/frank/agent-loop.ts
@@ -13,9 +13,14 @@ export type ToolResult = {
 export type FrankRiskLevel = 'LOW_RISK' | 'MEDIUM_RISK' | 'HIGH_RISK';
 
 export type FrankAgentAction =
+    | 'READ_CONVERSATION_CONTEXT'
+    | 'READ_CUSTOMER_CRM_CONTEXT'
     | 'READ_QUOTE_CONTEXT'
     | 'REQUEST_QUOTE_APPROVAL'
+    | 'TRACK_SHIPMENT_STATUS'
     | 'CREATE_ORDER_FROM_ACCEPTED_QUOTE';
+
+export type FrankSubAgent = 'ATENDIMENTO' | 'CRM' | 'FREIGHT' | 'LOGISTICA';
 
 export interface FrankAgentState {
     flowState: string;
@@ -40,18 +45,43 @@ export interface FrankPlannerInput {
     requestedAction: FrankAgentAction;
 }
 
+export interface FrankPlanDecision {
+    action: FrankAgentAction;
+    subAgent: FrankSubAgent;
+    handoff?: string;
+}
+
 const ACTION_RISK_MAP: Record<FrankAgentAction, FrankRiskLevel> = {
+    READ_CONVERSATION_CONTEXT: 'LOW_RISK',
+    READ_CUSTOMER_CRM_CONTEXT: 'LOW_RISK',
     READ_QUOTE_CONTEXT: 'LOW_RISK',
     REQUEST_QUOTE_APPROVAL: 'MEDIUM_RISK',
+    TRACK_SHIPMENT_STATUS: 'MEDIUM_RISK',
     CREATE_ORDER_FROM_ACCEPTED_QUOTE: 'HIGH_RISK',
 };
 
-export function decideNextAction(input: FrankPlannerInput, state: FrankAgentState): FrankAgentAction {
+const ACTION_SUB_AGENT_MAP: Record<FrankAgentAction, FrankSubAgent> = {
+    READ_CONVERSATION_CONTEXT: 'ATENDIMENTO',
+    READ_CUSTOMER_CRM_CONTEXT: 'CRM',
+    READ_QUOTE_CONTEXT: 'FREIGHT',
+    REQUEST_QUOTE_APPROVAL: 'FREIGHT',
+    TRACK_SHIPMENT_STATUS: 'LOGISTICA',
+    CREATE_ORDER_FROM_ACCEPTED_QUOTE: 'LOGISTICA',
+};
+
+export function decideNextAction(input: FrankPlannerInput, state: FrankAgentState): FrankPlanDecision {
     if (input.requestedAction === 'CREATE_ORDER_FROM_ACCEPTED_QUOTE' && state.quoteStatus !== 'ACCEPTED') {
-        return 'CREATE_ORDER_FROM_ACCEPTED_QUOTE';
+        return {
+            action: 'CREATE_ORDER_FROM_ACCEPTED_QUOTE',
+            subAgent: 'FREIGHT',
+            handoff: 'Aguardando quote aprovada; logística depende de precondição do Freight.',
+        };
     }
 
-    return input.requestedAction;
+    return {
+        action: input.requestedAction,
+        subAgent: ACTION_SUB_AGENT_MAP[input.requestedAction],
+    };
 }
 
 export function evaluatePolicy(input: FrankPolicyInput): FrankPolicyDecision {
@@ -62,14 +92,21 @@ export function evaluatePolicy(input: FrankPolicyInput): FrankPolicyDecision {
             riskLevel,
             allowed: false,
             reason: 'A cotacao precisa estar aprovada antes de criar o pedido.',
-            nextAllowedActions: ['READ_QUOTE_CONTEXT', 'REQUEST_QUOTE_APPROVAL'],
+            nextAllowedActions: ['READ_QUOTE_CONTEXT', 'REQUEST_QUOTE_APPROVAL', 'READ_CUSTOMER_CRM_CONTEXT'],
         };
     }
 
     return {
         riskLevel,
         allowed: true,
-        nextAllowedActions: ['READ_QUOTE_CONTEXT', 'REQUEST_QUOTE_APPROVAL', 'CREATE_ORDER_FROM_ACCEPTED_QUOTE'],
+        nextAllowedActions: [
+            'READ_CONVERSATION_CONTEXT',
+            'READ_CUSTOMER_CRM_CONTEXT',
+            'READ_QUOTE_CONTEXT',
+            'REQUEST_QUOTE_APPROVAL',
+            'TRACK_SHIPMENT_STATUS',
+            'CREATE_ORDER_FROM_ACCEPTED_QUOTE',
+        ],
     };
 }
 
@@ -95,8 +132,8 @@ export async function runFrankAgentTool(params: {
     const start = Date.now();
 
     const memory = buildAgentMemory({ quoteStatus: params.quoteStatus });
-    const plannedAction = decideNextAction({ requestedAction: params.action }, memory);
-    const policy = evaluatePolicy({ action: plannedAction, quoteStatus: params.quoteStatus });
+    const planned = decideNextAction({ requestedAction: params.action }, memory);
+    const policy = evaluatePolicy({ action: planned.action, quoteStatus: params.quoteStatus });
 
     if (!policy.allowed) {
         const blockedMemory = buildAgentMemory({
@@ -113,6 +150,8 @@ export async function runFrankAgentTool(params: {
             nextAllowedActions: policy.nextAllowedActions,
             audit: {
                 riskLevel: policy.riskLevel,
+                subAgent: planned.subAgent,
+                handoff: planned.handoff ?? null,
                 flowState: blockedMemory.flowState,
                 lastActionExecuted: blockedMemory.lastActionExecuted,
                 lastBlockReason: blockedMemory.lastBlockReason,
@@ -121,7 +160,9 @@ export async function runFrankAgentTool(params: {
 
         logger.info('frank_agent_loop_execution', {
             requestId: params.requestId,
-            action: plannedAction,
+            action: planned.action,
+            subAgent: planned.subAgent,
+            handoff: planned.handoff ?? null,
             outcome: blockedResult.status,
             durationMs: Date.now() - start,
         });
@@ -133,7 +174,7 @@ export async function runFrankAgentTool(params: {
         const data = await params.execute();
         const doneMemory = buildAgentMemory({
             quoteStatus: params.quoteStatus,
-            lastActionExecuted: plannedAction,
+            lastActionExecuted: planned.action,
         });
 
         const success: ToolResult = {
@@ -143,6 +184,8 @@ export async function runFrankAgentTool(params: {
             nextAllowedActions: policy.nextAllowedActions,
             audit: {
                 riskLevel: policy.riskLevel,
+                subAgent: planned.subAgent,
+                handoff: planned.handoff ?? null,
                 flowState: doneMemory.flowState,
                 lastActionExecuted: doneMemory.lastActionExecuted,
             },
@@ -150,7 +193,9 @@ export async function runFrankAgentTool(params: {
 
         logger.info('frank_agent_loop_execution', {
             requestId: params.requestId,
-            action: plannedAction,
+            action: planned.action,
+            subAgent: planned.subAgent,
+            handoff: planned.handoff ?? null,
             outcome: success.status,
             durationMs: Date.now() - start,
         });
@@ -166,14 +211,18 @@ export async function runFrankAgentTool(params: {
             nextAllowedActions: policy.nextAllowedActions,
             audit: {
                 riskLevel: policy.riskLevel,
+                subAgent: planned.subAgent,
+                handoff: planned.handoff ?? null,
                 flowState: memory.flowState,
-                lastActionExecuted: plannedAction,
+                lastActionExecuted: planned.action,
             },
         };
 
         logger.info('frank_agent_loop_execution', {
             requestId: params.requestId,
-            action: plannedAction,
+            action: planned.action,
+            subAgent: planned.subAgent,
+            handoff: planned.handoff ?? null,
             outcome: failed.status,
             durationMs: Date.now() - start,
         });


### PR DESCRIPTION
### Motivation
- Reduce coupling inside the Frank agent loop by assigning each planner action to a clear sub-agent responsibility (`ATENDIMENTO`, `CRM`, `FREIGHT`, `LOGISTICA`) to meet MPV-27 acceptance criteria. 
- Make cross-domain handoffs explicit and traceable in telemetry so operational troubleshooting and governance are simpler and auditable. 
- Preserve the centralized orchestrator entrypoint and supervised runtime behavior while improving separation of concerns.

### Description
- Introduces new actions and sub-agent concepts in `src/modules/frank/agent-loop.ts` by adding `FrankSubAgent`, `FrankPlanDecision`, `ACTION_SUB_AGENT_MAP` and by returning a planner decision (`action`, `subAgent`, optional `handoff`).
- Adds handoff metadata when preconditions are missing (e.g. creating an order before quote acceptance) and surfaces `subAgent`/`handoff` in the loop `audit` and logs for traceability. 
- Extends allowed/next action list and policy responses to include CRM/conversation reads and shipment tracking where relevant. 
- Updates unit tests to assert the new `audit` contract and updates documentation entries in `README.md` and `ARCHITECTURE.md` to reflect sub-agent separation. 
- Files changed: `src/modules/frank/agent-loop.ts`, `src/modules/frank/__tests__/agent-loop.test.ts`, `README.md`, `ARCHITECTURE.md`.

### Testing
- `npm run guardrail:mvp-freeze` (with `ALLOW_FROZEN_SURFACE_CHANGES=1`) could not complete in this environment due to missing remote ref and reported as a non-blocking environment limitation. 
- `npm run scope:pr-tests -- --files src/modules/frank/agent-loop.ts src/modules/frank/__tests__/agent-loop.test.ts README.md ARCHITECTURE.md` succeeded and recommended the minimal guardrail for this diff. 
- Unit tests were run with `AUTH_SECRET=test-secret PII_ENCRYPTION_KEY=12345678901234567890123456789012 NODE_ENV=development npx vitest run --configLoader runner --config vitest.config.mjs src/modules/frank/__tests__/agent-loop.test.ts` and all tests passed (3 tests). 
- Typechecking (`npm run typecheck`) and linting (`npm run lint`) were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce187f58e48331bc04d68523bdd68c)