### PR TITLE
feat: auditar decisões humanas no ciclo de sugestão

### DIFF
--- a/src/modules/audit/operational-audit.service.ts
+++ b/src/modules/audit/operational-audit.service.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import { eq, and, asc, desc } from 'drizzle-orm';
 import { logger } from '@/infra/logger';
 
-export type OperationalEntityType = 'opportunity' | 'order' | 'client' | 'conversation' | 'shipment';
+export type OperationalEntityType = 'opportunity' | 'order' | 'client' | 'conversation' | 'shipment' | 'suggestion';
 export type ActionOrigin = 'ui' | 'bulk' | 'drawer' | 'palette' | 'frank' | 'system';
 
 export interface LogOperationalActivityParams {

--- a/src/modules/frank/suggestions/__tests__/suggestion.service.test.ts
+++ b/src/modules/frank/suggestions/__tests__/suggestion.service.test.ts
@@ -4,6 +4,7 @@ const mockCreate = vi.hoisted(() => vi.fn());
 const mockFindById = vi.hoisted(() => vi.fn());
 const mockUpdateStatus = vi.hoisted(() => vi.fn());
 const mockListPending = vi.hoisted(() => vi.fn());
+const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/events/operational-event-bus', () => ({
     publishOperationalEvent: vi.fn().mockResolvedValue(undefined)
@@ -18,11 +19,18 @@ vi.mock('../suggestion.repository', () => ({
     }
 }));
 
+vi.mock('@/modules/audit/operational-audit.service', () => ({
+    operationalAuditService: {
+        logActivity: mockLogActivity,
+    },
+}));
+
 import { suggestionService } from '../suggestion.service';
 
 describe('SuggestionService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockLogActivity.mockResolvedValue(undefined);
     });
 
     it('generateSuggestion should create and emit event', async () => {
@@ -54,6 +62,13 @@ describe('SuggestionService', () => {
 
         expect(ok).toBe(true);
         expect(mockUpdateStatus).toHaveBeenCalledWith('tenant-1', 'sugg-1', 'approved', 'op-1', 'Original');
+        expect(mockLogActivity).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-1',
+            entityType: 'suggestion',
+            entityId: 'sugg-1',
+            actorId: 'op-1',
+            actionType: 'suggestion_approved',
+        }));
     });
 
     it('approveSuggestion should update status and emit edited event', async () => {
@@ -71,6 +86,13 @@ describe('SuggestionService', () => {
 
         expect(ok).toBe(true);
         expect(mockUpdateStatus).toHaveBeenCalledWith('tenant-1', 'sugg-2', 'edited', 'op-1', 'Edited');
+        expect(mockLogActivity).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-1',
+            entityType: 'suggestion',
+            entityId: 'sugg-2',
+            actorId: 'op-1',
+            actionType: 'suggestion_edited',
+        }));
     });
 
     it('rejectSuggestion should update status to rejected', async () => {
@@ -84,5 +106,12 @@ describe('SuggestionService', () => {
 
         expect(ok).toBe(true);
         expect(mockUpdateStatus).toHaveBeenCalledWith('tenant-1', 'sugg-3', 'rejected', 'op-1');
+        expect(mockLogActivity).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-1',
+            entityType: 'suggestion',
+            entityId: 'sugg-3',
+            actorId: 'op-1',
+            actionType: 'suggestion_rejected',
+        }));
     });
 });

--- a/src/modules/frank/suggestions/suggestion.service.ts
+++ b/src/modules/frank/suggestions/suggestion.service.ts
@@ -5,8 +5,9 @@ import {
     emitSuggestionEdited,
     emitSuggestionRejected
 } from './suggestion.events';
-import { CreateSuggestionDTO, ApproveSuggestionDTO, FrankSuggestion } from './suggestion.types';
+import { CreateSuggestionDTO, ApproveSuggestionDTO } from './suggestion.types';
 import { logger } from '@/infra/logger';
+import { operationalAuditService } from '@/modules/audit/operational-audit.service';
 
 export class SuggestionService {
     async generateSuggestion(tenantId: string, sessionId: string, dto: CreateSuggestionDTO): Promise<string> {
@@ -60,10 +61,44 @@ export class SuggestionService {
                 approvedBy: dto.operatorId,
                 edited: isEdited
             };
+            const actionType = isEdited ? 'suggestion_edited' : 'suggestion_approved';
+            const currentResponse = dto.finalResponse ?? existing.suggestedResponse;
+            const decisionContext = {
+                conversationId: existing.conversationId,
+                sessionId: existing.sessionId,
+                intent: existing.intent,
+            };
 
             logger.info(`frank_suggestion_${status}`, payload);
             if (isEdited) emitSuggestionEdited(tenantId, payload);
             else emitSuggestionApproved(tenantId, payload);
+
+            await operationalAuditService.logActivity({
+                tenantId,
+                entityType: 'suggestion',
+                entityId: id,
+                actorId: dto.operatorId,
+                actionType,
+                origin: 'frank',
+                beforeState: {
+                    status: existing.status,
+                    suggestedResponse: existing.suggestedResponse,
+                    approvedBy: existing.approvedBy,
+                    approvedAt: existing.approvedAt,
+                },
+                afterState: {
+                    status,
+                    suggestedResponse: currentResponse,
+                    approvedBy: dto.operatorId,
+                },
+                metadata: {
+                    ...decisionContext,
+                    decisionContext: {
+                        action: status,
+                        edited: isEdited,
+                    },
+                },
+            });
         }
 
         return ok;
@@ -88,6 +123,33 @@ export class SuggestionService {
             };
             logger.info('frank_suggestion_rejected', payload);
             emitSuggestionRejected(tenantId, payload);
+
+            await operationalAuditService.logActivity({
+                tenantId,
+                entityType: 'suggestion',
+                entityId: id,
+                actorId: operatorId,
+                actionType: 'suggestion_rejected',
+                origin: 'frank',
+                beforeState: {
+                    status: existing.status,
+                    suggestedResponse: existing.suggestedResponse,
+                    approvedBy: existing.approvedBy,
+                    approvedAt: existing.approvedAt,
+                },
+                afterState: {
+                    status: 'rejected',
+                    approvedBy: operatorId,
+                },
+                metadata: {
+                    conversationId: existing.conversationId,
+                    sessionId: existing.sessionId,
+                    intent: existing.intent,
+                    decisionContext: {
+                        action: 'rejected',
+                    },
+                },
+            });
         }
 
         return ok;


### PR DESCRIPTION
### Motivation
- Rastrear decisões humanas no fluxo de sugestões para auditoria operacional e observabilidade sem alterar o comportamento atual do serviço.
- Garantir que aprovações, edições e rejeições de sugestões registrem operador, contexto e estados antes/depois para investigação e métricas.

### Description
- Adiciona chamadas de auditoria em `SuggestionService` para os três caminhos de decisão humana (`approve`, `edit`, `reject`) e preserva o fluxo existente sem mudar lógica de decisão. 
- Estende o tipo `OperationalEntityType` em `src/modules/audit/operational-audit.service.ts` para incluir `suggestion`. 
- Registra `actorId`, `actionType` (`suggestion_approved`, `suggestion_edited`, `suggestion_rejected`), `origin: 'frank'`, `beforeState` e `afterState`, além do contexto (`conversationId`, `sessionId`, `intent`, `decisionContext`).
- Atualiza testes unitários em `src/modules/frank/suggestions/__tests__/suggestion.service.test.ts` para mockar `operationalAuditService.logActivity` e validar que logs de auditoria são emitidos em todos os caminhos.

### Testing
- Ran `npm run scope:pr-tests -- --files src/modules/frank/suggestions/suggestion.service.ts src/modules/audit/operational-audit.service.ts src/modules/frank/suggestions/__tests__/suggestion.service.test.ts` which reported the expected minimal test scope. ✅
- Ran `npm run guardrail:mvp-freeze` which failed due to the local environment limitation (`origin/main...HEAD` unavailable). ⚠️
- Ran the suggestion unit tests with `npx vitest run --configLoader runner --config vitest.config.mjs src/modules/frank/suggestions/__tests__/suggestion.service.test.ts` and they passed. ✅
- Ran the broader suite `npm run test:mvp` and the targeted MVP test groups executed and passed in this environment. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce18b3d5688331a33b3b5925308e84)