### PR TITLE
[codex] Fail fast on critical runtime secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
     env:
       # Optional CI secrets (recommended):
       # - CI_AUTH_SECRET
+      # - CI_DATABASE_URL
       # - CI_PII_ENCRYPTION_KEY (64 hex chars)
       # Fallbacks below are CI-only and never used by app runtime in production.
-      AUTH_SECRET: ${{ secrets.CI_AUTH_SECRET != '' && secrets.CI_AUTH_SECRET || 'ci-only-auth-secret-quality-gate' }}
-      PII_ENCRYPTION_KEY: ${{ secrets.CI_PII_ENCRYPTION_KEY != '' && secrets.CI_PII_ENCRYPTION_KEY || '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff' }}
+      AUTH_SECRET: ${{ secrets.CI_AUTH_SECRET != '' && secrets.CI_AUTH_SECRET || '5d2c9b7d6571b070c0f8389c7d44ed3b8b7d6a4095d29646d09aa854f17caa6e' }}
+      DATABASE_URL: ${{ secrets.CI_DATABASE_URL != '' && secrets.CI_DATABASE_URL || 'mysql://ci_user:ci_password@127.0.0.1:3306/condstore_ci' }}
+      PII_ENCRYPTION_KEY: ${{ secrets.CI_PII_ENCRYPTION_KEY != '' && secrets.CI_PII_ENCRYPTION_KEY || '6f2d2a4d8f9e6ab34b45d8b0d2e53c4a7b198d4f5566778899aabbccddeeff01' }}
 
     steps:
       - name: Checkout Repository
@@ -103,8 +105,9 @@ jobs:
           CI: "true"
           GITHUB_ACTIONS: "true"
           QA_BOOTSTRAP_TOKEN: ${{ secrets.QA_BOOTSTRAP_TOKEN }}
-          DATABASE_URL: mysql://root:root@localhost:3306/condstore_dev
-          AUTH_SECRET: dev-secret-ci
+          DATABASE_URL: ${{ secrets.CI_DATABASE_URL != '' && secrets.CI_DATABASE_URL || 'mysql://ci_user:ci_password@127.0.0.1:3306/condstore_ci' }}
+          AUTH_SECRET: ${{ secrets.CI_AUTH_SECRET != '' && secrets.CI_AUTH_SECRET || '5d2c9b7d6571b070c0f8389c7d44ed3b8b7d6a4095d29646d09aa854f17caa6e' }}
+          PII_ENCRYPTION_KEY: ${{ secrets.CI_PII_ENCRYPTION_KEY != '' && secrets.CI_PII_ENCRYPTION_KEY || '6f2d2a4d8f9e6ab34b45d8b0d2e53c4a7b198d4f5566778899aabbccddeeff01' }}
         run: |
           npm run start -- -p 3002 &
           echo "Waiting for Next.js to start..."

--- a/scripts/check-critical-secrets.mjs
+++ b/scripts/check-critical-secrets.mjs
@@ -1,49 +1,121 @@
 #!/usr/bin/env node
 
 /**
- * CI health check for critical secrets.
- * Scope intentionally minimal:
- * - AUTH_SECRET must exist and must not be a known dev fallback.
- * - PII_ENCRYPTION_KEY must exist outside development and have 32-byte hex format.
+ * CI health check for critical env vars.
+ * Outside NODE_ENV=development we fail hard on:
+ * - missing AUTH_SECRET, DATABASE_URL or PII_ENCRYPTION_KEY
+ * - known hardcoded / placeholder values
+ * - weak AUTH_SECRET values (< 32 bytes)
+ * - invalid PII_ENCRYPTION_KEY format (< 32 bytes or not a valid 32-byte key)
  */
 
-const nodeEnv = (process.env.NODE_ENV || '').trim().toLowerCase();
-const isDevelopment = nodeEnv === 'development';
+import { pathToFileURL } from 'node:url';
+
+const AUTH_SECRET_MIN_BYTES = 32;
+const PII_KEY_BYTES = 32;
+const DEV_ONLY_DATABASE_URL_FALLBACK = 'mysql://root:root@localhost:3306/condstore_dev';
 
 const knownAuthFallbacks = new Set([
   'dev-only-fallback-secret-do-not-use-in-prod',
   'dev-only-auth-secret-do-not-use-in-prod',
+  'ci-only-auth-secret-quality-gate',
+  'dev-secret-ci',
 ]);
 
-const errors = [];
+const knownPiiFallbacks = new Set([
+  'dev-only-pii-encryption-key',
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
+]);
 
-function readEnv(name) {
-  const value = process.env[name];
+const insecurePlaceholderPatterns = [
+  /changeme/i,
+  /change-this/i,
+  /placeholder/i,
+  /dummy/i,
+  /example/i,
+  /replace-me/i,
+  /^test-secret/i,
+];
+
+function readEnv(env, name) {
+  const value = env[name];
   return typeof value === 'string' ? value.trim() : '';
 }
 
-const authSecret = readEnv('AUTH_SECRET');
-if (!authSecret) {
-  errors.push('AUTH_SECRET is missing');
-} else if (knownAuthFallbacks.has(authSecret)) {
-  errors.push('AUTH_SECRET is using a forbidden dev fallback value');
+function looksLikePlaceholder(value) {
+  return insecurePlaceholderPatterns.some((pattern) => pattern.test(value));
 }
 
-if (!isDevelopment) {
-  const piiKey = readEnv('PII_ENCRYPTION_KEY');
+function parsePiiKeyLength(value) {
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return Buffer.from(value, 'hex').length;
+  }
+
+  return Buffer.from(value, 'base64').length;
+}
+
+export function validateCriticalSecrets(env = process.env) {
+  const errors = [];
+  const runtimeEnv = readEnv(env, 'NODE_ENV').toLowerCase();
+  const developmentMode = runtimeEnv === 'development';
+
+  const authSecret = readEnv(env, 'AUTH_SECRET');
+  if (!authSecret) {
+    if (!developmentMode) {
+      errors.push('AUTH_SECRET is missing outside NODE_ENV=development');
+    }
+  } else {
+    if (knownAuthFallbacks.has(authSecret) || looksLikePlaceholder(authSecret)) {
+      errors.push('AUTH_SECRET is using a forbidden fallback or placeholder value');
+    }
+
+    if (Buffer.byteLength(authSecret, 'utf8') < AUTH_SECRET_MIN_BYTES) {
+      errors.push(`AUTH_SECRET must be at least ${AUTH_SECRET_MIN_BYTES} bytes`);
+    }
+  }
+
+  const databaseUrl = readEnv(env, 'DATABASE_URL');
+  if (!databaseUrl) {
+    errors.push('DATABASE_URL is missing');
+  } else if (!developmentMode && databaseUrl === DEV_ONLY_DATABASE_URL_FALLBACK) {
+    errors.push('DATABASE_URL is using the forbidden local default fallback');
+  }
+
+  const piiKey = readEnv(env, 'PII_ENCRYPTION_KEY');
   if (!piiKey) {
-    errors.push('PII_ENCRYPTION_KEY is missing outside development');
-  } else if (!/^[0-9a-fA-F]{64}$/.test(piiKey)) {
-    errors.push('PII_ENCRYPTION_KEY must be 64 hex chars (32 bytes)');
+    if (!developmentMode) {
+      errors.push('PII_ENCRYPTION_KEY is missing outside NODE_ENV=development');
+    }
+  } else {
+    if (knownPiiFallbacks.has(piiKey) || looksLikePlaceholder(piiKey)) {
+      errors.push('PII_ENCRYPTION_KEY is using a forbidden fallback or placeholder value');
+    }
+
+    const decodedLength = parsePiiKeyLength(piiKey);
+    if (decodedLength !== PII_KEY_BYTES) {
+      errors.push(
+        `PII_ENCRYPTION_KEY must decode to exactly ${PII_KEY_BYTES} bytes (minimum entropy requirement is ${PII_KEY_BYTES} bytes)`,
+      );
+    }
   }
+
+  return errors;
 }
 
-if (errors.length > 0) {
-  console.error('[critical-secrets] FAILED');
-  for (const error of errors) {
-    console.error(`- ${error}`);
+function run() {
+  const errors = validateCriticalSecrets(process.env);
+
+  if (errors.length > 0) {
+    console.error('[critical-secrets] FAILED');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
   }
-  process.exit(1);
+
+  console.log('[critical-secrets] OK');
 }
 
-console.log('[critical-secrets] OK');
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run();
+}

--- a/src/ARCHITECTURE_COCKPIT.md
+++ b/src/ARCHITECTURE_COCKPIT.md
@@ -40,7 +40,7 @@ Browser                    Next.js                    JWT / Cookie
 - `src/middleware.ts` — JWT verification, header injection, RBAC enforcement
 
 **Cookie:** name `condstore_session`, defined once in `src/infra/auth/session.ts`.
-**Secret:** `AUTH_SECRET` env var (HS256). Falls back to dev-only string when unset — sessions survive but a warning is logged. Set in `.env.local` for local dev.
+**Secret:** `AUTH_SECRET` env var (HS256). A dev-only fallback is accepted only when `NODE_ENV=development`; every other runtime fails fast if the secret is missing or uses a forbidden fallback value.
 
 ---
 

--- a/src/__tests__/internal-auth-contract.test.ts
+++ b/src/__tests__/internal-auth-contract.test.ts
@@ -95,14 +95,27 @@ describe('internal auth contract', () => {
     process.env.INTERNAL_DIAG_TOKEN = 'diag-secret';
     process.env.INTERNAL_EXPORT_TOKEN = 'export-secret';
     process.env.INTERNAL_JOB_TOKEN = 'job-secret';
+    process.env.PII_ENCRYPTION_KEY = '6f2d2a4d8f9e6ab34b45d8b0d2e53c4a7b198d4f5566778899aabbccddeeff01';
     delete process.env.AUTH_SECRET;
 
     expect(() => assertCriticalEnvSetup()).toThrow(/AUTH_SECRET/);
   });
 
+  it('still requires PII_ENCRYPTION_KEY in strict runtimes', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    process.env.VERCEL_ENV = 'production';
+    process.env.INTERNAL_DIAG_TOKEN = 'diag-secret';
+    process.env.INTERNAL_EXPORT_TOKEN = 'export-secret';
+    process.env.INTERNAL_JOB_TOKEN = 'job-secret';
+    delete process.env.PII_ENCRYPTION_KEY;
+
+    expect(() => assertCriticalEnvSetup()).toThrow(/PII_ENCRYPTION_KEY/);
+  });
+
   it('fails early in strict runtime when critical internal tokens are missing', () => {
     vi.stubEnv('NODE_ENV', 'production');
     process.env.VERCEL_ENV = 'preview';
+    process.env.PII_ENCRYPTION_KEY = '6f2d2a4d8f9e6ab34b45d8b0d2e53c4a7b198d4f5566778899aabbccddeeff01';
 
     expect(() => assertCriticalEnvSetup()).toThrow(
       /INTERNAL_DIAG_TOKEN, INTERNAL_EXPORT_TOKEN, INTERNAL_JOB_TOKEN/,

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -13,6 +13,9 @@ vi.mock('jose', () => ({
 describe('Middleware', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.unstubAllEnvs();
+        vi.stubEnv('AUTH_SECRET', 'middleware-auth-secret-with-32-bytes');
+        vi.stubEnv('NODE_ENV', 'test');
     });
 
     it('blocks unauthenticated access to /api/ routes with 401', async () => {
@@ -77,5 +80,21 @@ describe('Middleware', () => {
         
         // Let's verify our jose mock was called
         expect(jwtVerify).toHaveBeenCalled();
+    });
+
+    it('fails fast outside development when AUTH_SECRET is missing', async () => {
+        delete process.env.AUTH_SECRET;
+
+        const req = new NextRequest('http://localhost/api/protected');
+        req.cookies.set('condstore_session', 'mock-valid-token');
+
+        const res = await middleware(req);
+
+        expect(res.status).toBe(500);
+        const data = await res.json();
+        expect(data).toEqual({
+            error: 'Internal Server Error',
+            code: 'MISSING_AUTH_SECRET',
+        });
     });
 });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -11,6 +11,7 @@ import { structuredLogger } from '@/infra/log/logger';
 import { hashRateLimitKeyForLog, rateLimiter } from '@/infra/security/rate-limiter';
 import { auditService } from '@/modules/audit/audit.service';
 import { InfrastructureError, getUserMessage } from '@/infra/errors';
+import { getAuthSecretValue, requireDatabaseUrl } from '@/infra/env/critical-runtime';
 import { isDevRuntime } from '@/infra/env/devOnly';
 import { safeCompare } from '@/lib/security/safe-compare';
 
@@ -67,27 +68,31 @@ function logLoginDiagnostic(input: {
     structuredLogger.warn('auth_login_rejected', context);
 }
 
+function validateCriticalLoginEnv(requestId: string): NextResponse | null {
+    try {
+        requireDatabaseUrl();
+        getAuthSecretValue();
+        return null;
+    } catch (error) {
+        const code = error instanceof Error ? error.message : 'AUTH_LOGIN_MISCONFIGURED';
+        logger.error('CRITICAL: auth login runtime misconfiguration', error as Error, {
+            requestId,
+            code,
+        });
+        return NextResponse.json(
+            { success: false, error: 'Internal Server Error', code },
+            { status: 500 },
+        );
+    }
+}
+
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID?.() ?? `${Date.now()}`;
-    // 5) Validação de Variáveis de Ambiente e Fallback
-    const dbUrl = process.env.DATABASE_URL;
-    const authSecret = process.env.AUTH_SECRET || process.env.JWT_SECRET;
-
-    if (!dbUrl) {
-        if (process.env.NODE_ENV === 'production') {
-            logger.error('CRITICAL: DATABASE_URL is missing in production');
-            return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
-        }
-        process.env.DATABASE_URL = 'mysql://root:root@localhost:3306/condstore_dev';
+    const misconfigured = validateCriticalLoginEnv(requestId);
+    if (misconfigured) {
+        return misconfigured;
     }
 
-    if (!authSecret) {
-        if (process.env.NODE_ENV === 'production') {
-            logger.error('CRITICAL: AUTH_SECRET is missing in production');
-            return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
-        }
-        process.env.AUTH_SECRET = 'dev-only-fallback-secret-do-not-use-in-prod';
-    }
     let loginEmailHash: string | undefined;
 
     try {

--- a/src/infra/auth/session.ts
+++ b/src/infra/auth/session.ts
@@ -2,8 +2,8 @@ import { SignJWT, jwtVerify } from 'jose';
 import { NextRequest } from 'next/server';
 import { cookies } from 'next/headers';
 import { logger } from '../logger';
+import { getAuthSecretBytes } from '../env/critical-runtime';
 import { userRepository } from '../repositories/user.repository';
-import { isDevRuntime, isQaAutomation } from '../env/devOnly';
 
 export const COOKIE_NAME = 'condstore_session';
 const TOKEN_EXPIRY = '8h';
@@ -17,15 +17,7 @@ export interface SessionPayload {
 }
 
 export function getSecret(): Uint8Array {
-    const secret = process.env.AUTH_SECRET;
-    if (!secret) {
-        if (process.env.NODE_ENV === 'production') {
-            throw new Error('AUTH_SECRET is not set in production');
-        }
-        logger.warn('AUTH_SECRET not set, using dev fallback -- sessions will not survive restarts');
-        return new TextEncoder().encode('dev-only-fallback-secret-do-not-use-in-prod');
-    }
-    return new TextEncoder().encode(secret);
+    return getAuthSecretBytes();
 }
 
 export async function createSessionToken(user: {

--- a/src/infra/env/critical-runtime.ts
+++ b/src/infra/env/critical-runtime.ts
@@ -1,0 +1,68 @@
+const textEncoder = new TextEncoder();
+
+export const AUTH_SECRET_MIN_BYTES = 32;
+export const DEV_ONLY_AUTH_SECRET_FALLBACK = 'dev-only-fallback-secret-do-not-use-in-prod';
+export const LEGACY_DEV_ONLY_AUTH_SECRET_FALLBACK = 'dev-only-auth-secret-do-not-use-in-prod';
+export const DEV_ONLY_DATABASE_URL_FALLBACK = 'mysql://root:root@localhost:3306/condstore_dev';
+
+const warnedFallbacks = new Set<string>();
+const forbiddenAuthSecretValues = new Set([
+  DEV_ONLY_AUTH_SECRET_FALLBACK,
+  LEGACY_DEV_ONLY_AUTH_SECRET_FALLBACK,
+]);
+
+function warnOnce(key: string, message: string) {
+  if (warnedFallbacks.has(key)) {
+    return;
+  }
+
+  warnedFallbacks.add(key);
+  console.warn(message);
+}
+
+export function isDevelopmentRuntimeStrict(): boolean {
+  return process.env.NODE_ENV === 'development';
+}
+
+export function readTrimmedEnv(name: string): string | null {
+  const value = process.env[name]?.trim();
+  return value ? value : null;
+}
+
+export function getAuthSecretValue(): string {
+  const configured = readTrimmedEnv('AUTH_SECRET');
+  if (configured) {
+    if (!isDevelopmentRuntimeStrict() && forbiddenAuthSecretValues.has(configured)) {
+      throw new Error('INSECURE_AUTH_SECRET');
+    }
+
+    return configured;
+  }
+
+  if (isDevelopmentRuntimeStrict()) {
+    warnOnce(
+      'AUTH_SECRET',
+      '[auth] AUTH_SECRET missing in NODE_ENV=development; using dev-only fallback secret',
+    );
+    return DEV_ONLY_AUTH_SECRET_FALLBACK;
+  }
+
+  throw new Error('MISSING_AUTH_SECRET');
+}
+
+export function getAuthSecretBytes(): Uint8Array {
+  return textEncoder.encode(getAuthSecretValue());
+}
+
+export function requireDatabaseUrl(): string {
+  const databaseUrl = readTrimmedEnv('DATABASE_URL');
+  if (!databaseUrl) {
+    throw new Error('MISSING_DATABASE_URL');
+  }
+
+  if (!isDevelopmentRuntimeStrict() && databaseUrl === DEV_ONLY_DATABASE_URL_FALLBACK) {
+    throw new Error('INSECURE_DATABASE_URL');
+  }
+
+  return databaseUrl;
+}

--- a/src/infra/env/require-env.ts
+++ b/src/infra/env/require-env.ts
@@ -1,11 +1,13 @@
 import { getMissingCriticalInternalTokenEnvs, isStrictRuntimeEnvironment } from '../config/internal-token-contract';
+import { getAuthSecretValue, isDevelopmentRuntimeStrict, readTrimmedEnv, requireDatabaseUrl } from './critical-runtime';
+import { getPiiEncryptionKey } from '../pii/crypto';
 
 export function requireEnv(key: string, fallback?: string): string {
-    const val = process.env[key];
+    const val = readTrimmedEnv(key);
     if (!val) {
         if (fallback !== undefined) {
-            if (!isStrictRuntimeEnvironment()) {
-                console.warn(`[WARN] Missing env ${key}. Using fallback in non-production environment.`);
+            if (isDevelopmentRuntimeStrict()) {
+                console.warn(`[WARN] Missing env ${key}. Using fallback only because NODE_ENV=development.`);
                 return fallback;
             }
         }
@@ -17,11 +19,12 @@ export function requireEnv(key: string, fallback?: string): string {
 export function assertCriticalEnvSetup() {
     if (process.env.NODE_ENV === 'test' || process.env.CI === 'true') return;
 
-    requireEnv('DATABASE_URL');
+    requireDatabaseUrl();
     requireEnv('NEXT_PUBLIC_APP_URL', 'http://localhost:3000');
+    getAuthSecretValue();
+    getPiiEncryptionKey();
 
     if (isStrictRuntimeEnvironment()) {
-        requireEnv('AUTH_SECRET');
         const missingInternalTokenEnvs = getMissingCriticalInternalTokenEnvs();
         if (missingInternalTokenEnvs.length > 0) {
             throw new Error(

--- a/src/infra/pii/__tests__/crypto.test.ts
+++ b/src/infra/pii/__tests__/crypto.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { decryptString, encryptString, isEncryptedString } from '../crypto';
 
 describe('pii/crypto', () => {
   const originalKey = process.env.PII_ENCRYPTION_KEY;
 
   beforeEach(() => {
-    process.env.PII_ENCRYPTION_KEY = '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'test');
+    process.env.PII_ENCRYPTION_KEY = '6f2d2a4d8f9e6ab34b45d8b0d2e53c4a7b198d4f5566778899aabbccddeeff01';
   });
 
   afterEach(() => {
@@ -21,6 +23,28 @@ describe('pii/crypto', () => {
 
     expect(isEncryptedString(ciphertext)).toBe(true);
     expect(ciphertext).not.toContain('conteudo sensivel');
+    expect(decryptString(ciphertext)).toBe('conteudo sensivel');
+  });
+
+  it('fails fast outside development when the key is missing', () => {
+    delete process.env.PII_ENCRYPTION_KEY;
+
+    expect(() => encryptString('conteudo sensivel')).toThrow('MISSING_PII_ENCRYPTION_KEY');
+  });
+
+  it('rejects insecure keys that do not decode to 32 bytes', () => {
+    process.env.PII_ENCRYPTION_KEY = 'short-key';
+
+    expect(() => encryptString('conteudo sensivel')).toThrow('INVALID_PII_ENCRYPTION_KEY_LENGTH');
+  });
+
+  it('preserves the development fallback only for NODE_ENV=development', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    delete process.env.PII_ENCRYPTION_KEY;
+
+    const ciphertext = encryptString('conteudo sensivel');
+
+    expect(isEncryptedString(ciphertext)).toBe(true);
     expect(decryptString(ciphertext)).toBe('conteudo sensivel');
   });
 });

--- a/src/infra/pii/crypto.ts
+++ b/src/infra/pii/crypto.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { isDevelopmentRuntimeStrict, readTrimmedEnv } from '../env/critical-runtime';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_BYTES = 12;
@@ -20,19 +21,19 @@ function parseConfiguredKey(raw: string): Buffer {
   return decoded;
 }
 
-function getPiiEncryptionKey(): Buffer {
-  const configured = process.env.PII_ENCRYPTION_KEY?.trim();
+export function getPiiEncryptionKey(): Buffer {
+  const configured = readTrimmedEnv('PII_ENCRYPTION_KEY');
   if (configured) {
     return parseConfiguredKey(configured);
   }
 
-  if (process.env.NODE_ENV === 'production') {
+  if (!isDevelopmentRuntimeStrict()) {
     throw new Error('MISSING_PII_ENCRYPTION_KEY');
   }
 
   if (!warnedMissingKey) {
     warnedMissingKey = true;
-    console.warn('[pii] PII_ENCRYPTION_KEY missing in dev/test; using insecure fallback encryption key');
+    console.warn('[pii] PII_ENCRYPTION_KEY missing in NODE_ENV=development; using dev-only fallback encryption key');
   }
 
   // Deterministic dev/test fallback to keep roundtrip behavior stable in local runs.

--- a/src/infra/pii/phone.ts
+++ b/src/infra/pii/phone.ts
@@ -1,23 +1,5 @@
 import { createHash, createHmac } from 'node:crypto';
-
-const DEV_AUTH_SECRET_FALLBACK = 'dev-only-auth-secret-do-not-use-in-prod';
-let warnedMissingAuthSecret = false;
-
-function getHashingSecret(): string {
-  const configured = process.env.AUTH_SECRET?.trim();
-  if (configured) return configured;
-
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('MISSING_AUTH_SECRET_FOR_PII_HASH');
-  }
-
-  if (!warnedMissingAuthSecret) {
-    warnedMissingAuthSecret = true;
-    console.warn('[pii] AUTH_SECRET missing in dev/test; using insecure fallback for phone hashing');
-  }
-
-  return DEV_AUTH_SECRET_FALLBACK;
-}
+import { getAuthSecretValue } from '../env/critical-runtime';
 
 export function normalizeE164(input: string): string {
   if (typeof input !== 'string') {
@@ -51,7 +33,7 @@ export function deriveTenantPhoneSalt(tenantId: string): string {
     throw new Error('INVALID_TENANT_ID_FOR_PHONE_HASH');
   }
 
-  return createHmac('sha256', getHashingSecret()).update(normalizedTenantId).digest('hex');
+  return createHmac('sha256', getAuthSecretValue()).update(normalizedTenantId).digest('hex');
 }
 
 export function phoneHash(e164: string, tenantSalt: string): string {

--- a/src/lib/security/edge-logger.ts
+++ b/src/lib/security/edge-logger.ts
@@ -1,3 +1,5 @@
+import { getAuthSecretValue, readTrimmedEnv } from '@/infra/env/critical-runtime';
+
 export interface EdgeSecurityEventInput {
     requestId: string;
     route: string;
@@ -9,9 +11,18 @@ export interface EdgeSecurityEventInput {
 
 export async function hashIp(ip: string | null | undefined): Promise<string | null> {
     if (!ip) return null;
-    // We add a pepper to the hash specifically for IP addresses to make rainbow tables harder
-    // For local edge hashing, if AUTH_SECRET is missing, we use a fallback pepper
-    const pepper = process.env.PII_ENCRYPTION_KEY || process.env.AUTH_SECRET || 'fallback-ip-pepper-condstore';
+    const pepper = readTrimmedEnv('PII_ENCRYPTION_KEY') ?? (() => {
+        try {
+            return getAuthSecretValue();
+        } catch (error) {
+            const code = error instanceof Error ? error.message : 'EDGE_HASH_SECRET_MISSING';
+            console.error('[edge-security] unable to derive IP hash pepper', { code });
+            return null;
+        }
+    })();
+    if (!pepper) {
+        return null;
+    }
     
     // Use Edge-compatible Web Crypto API instead of node:crypto
     const encoder = new TextEncoder();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ import {
     extractInternalRequestCredentials,
     isInternalTokenAuthorizedForPurpose,
 } from './infra/config/internal-token-contract';
+import { getAuthSecretBytes } from './infra/env/critical-runtime';
 import { logEdgeSecurityEvent } from './lib/security/edge-logger';
 
 const SESSION_COOKIE_NAME = 'condstore_session';
@@ -37,15 +38,7 @@ export const config = {
 };
 
 function getAuthSecret(): Uint8Array {
-    const secret = process.env.AUTH_SECRET?.trim();
-    if (!secret) {
-        if (process.env.NODE_ENV === 'production') {
-            // In production we strictly require the secret
-            throw new Error('MISCONFIG_AUTH_SECRET');
-        }
-        return new TextEncoder().encode('dev-only-fallback-secret-do-not-use-in-prod');
-    }
-    return new TextEncoder().encode(secret);
+    return getAuthSecretBytes();
 }
 
 interface MiddlewareSessionClaims {
@@ -55,8 +48,10 @@ interface MiddlewareSessionClaims {
 }
 
 async function verifyMiddlewareSessionToken(token: string): Promise<MiddlewareSessionClaims | null> {
+    const secret = getAuthSecret();
+
     try {
-        const { payload } = await jwtVerify(token, getAuthSecret());
+        const { payload } = await jwtVerify(token, secret);
         const claims = payload as JWTPayload & {
             tenantId?: unknown;
             role?: unknown;
@@ -93,6 +88,17 @@ function forbiddenJsonResponse(message = 'Forbidden'): NextResponse {
 function isPublicTrackingPath(pathname: string): boolean {
     const segments = pathname.split('/').filter(Boolean);
     return segments.length === 2 && segments[0] === 't';
+}
+
+function misconfiguredResponse(pathname: string, code: string): NextResponse {
+    if (pathname.startsWith('/api/')) {
+        return new NextResponse(JSON.stringify({ error: 'Internal Server Error', code }), {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    return new NextResponse('Internal Server Error', { status: 500 });
 }
 
 export async function middleware(req: NextRequest) {
@@ -211,7 +217,15 @@ export async function middleware(req: NextRequest) {
     }
 
     if (cookieToken) {
-        const session = await verifyMiddlewareSessionToken(cookieToken);
+        let session: MiddlewareSessionClaims | null;
+
+        try {
+            session = await verifyMiddlewareSessionToken(cookieToken);
+        } catch (error) {
+            const code = error instanceof Error ? error.message : 'MISCONFIG_AUTH_SECRET';
+            console.error('[middleware] failed fast due to auth secret misconfiguration', { code, pathname, requestId });
+            return misconfiguredResponse(pathname, code);
+        }
 
         if (!session) {
             await logEdgeSecurityEvent({

--- a/src/tests/auth/login-route.test.ts
+++ b/src/tests/auth/login-route.test.ts
@@ -3,7 +3,6 @@ import { NextRequest } from 'next/server';
 import { POST } from '@/app/api/auth/login/route';
 import { rateLimiter } from '@/infra/security/rate-limiter';
 import { userRepository } from '@/infra/repositories/user.repository';
-import * as passwordUtils from '@/infra/auth/password';
 
 vi.mock('@/infra/db', () => ({
     getDb: vi.fn(),
@@ -34,8 +33,10 @@ vi.mock('@/infra/auth/session', () => ({
 describe('Login API Route Hardening', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.unstubAllEnvs();
+        vi.stubEnv('NODE_ENV', 'test');
         process.env.DATABASE_URL = 'mysql://root:root@localhost:3306/db';
-        process.env.AUTH_SECRET = '1234567890123456';
+        process.env.AUTH_SECRET = 'login-auth-secret-with-32-bytes';
     });
 
     it('should return 429 JSON when rate limited, never HTML', async () => {
@@ -84,10 +85,8 @@ describe('Login API Route Hardening', () => {
         expect(data.error).toBe('Email ou senha inválidos');
     });
 
-    it('should return 500 JSON if critical envs missing (simulated 503/500), never HTML', async () => {
-        // Remove critical variables to trigger the fallback block inside POST
+    it('should return 500 JSON if DATABASE_URL is missing outside development', async () => {
         delete process.env.DATABASE_URL;
-        vi.stubEnv('NODE_ENV', 'production');
 
         const req = new NextRequest('http://localhost:3000/api/auth/login', {
             method: 'POST',
@@ -99,9 +98,10 @@ describe('Login API Route Hardening', () => {
         expect(res.headers.get('content-type')).toContain('application/json');
 
         const data = await res.json();
-        expect(data.success).toBe(false);
-        expect(data.error).toBeDefined();
-
-        vi.stubEnv('NODE_ENV', 'test'); // Restore for next tests
+        expect(data).toEqual({
+            success: false,
+            error: 'Internal Server Error',
+            code: 'MISSING_DATABASE_URL',
+        });
     });
 });

--- a/src/tests/check-critical-secrets.test.ts
+++ b/src/tests/check-critical-secrets.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { validateCriticalSecrets } from '../../scripts/check-critical-secrets.mjs';
+
+describe('check-critical-secrets', () => {
+  it('rejects weak AUTH_SECRET values and forbidden database fallbacks outside development', () => {
+    const errors = validateCriticalSecrets({
+      NODE_ENV: 'production',
+      AUTH_SECRET: 'short-secret',
+      DATABASE_URL: 'mysql://root:root@localhost:3306/condstore_dev',
+      PII_ENCRYPTION_KEY: '6f2d2a4d8f9e6ab34b45d8b0d2e53c4a7b198d4f5566778899aabbccddeeff01',
+    });
+
+    expect(errors).toEqual(expect.arrayContaining([
+      'AUTH_SECRET must be at least 32 bytes',
+      'DATABASE_URL is using the forbidden local default fallback',
+    ]));
+  });
+
+  it('rejects placeholder or invalid PII keys outside development', () => {
+    const errors = validateCriticalSecrets({
+      NODE_ENV: 'production',
+      AUTH_SECRET: 'auth-secret-with-at-least-32-bytes',
+      DATABASE_URL: 'mysql://ci_user:ci_password@127.0.0.1:3306/condstore_ci',
+      PII_ENCRYPTION_KEY: '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
+    });
+
+    expect(errors).toContain('PII_ENCRYPTION_KEY is using a forbidden fallback or placeholder value');
+  });
+});


### PR DESCRIPTION
## Context
This PR closes audit item #3 for silent production secret fallbacks.

Root cause:
- `src/middleware.ts` accepted a hardcoded `AUTH_SECRET` fallback outside strict development.
- `src/app/api/auth/login/route.ts` silently rewrote `DATABASE_URL` and `AUTH_SECRET` to local/dev defaults.
- `src/infra/pii/crypto.ts` derived the PII encryption key from a static dev string when the env var was absent.
- CI/runtime validation was not enforcing a strong, consistent contract for these critical env vars.

## Technical Decision
- Centralized critical runtime env handling in `src/infra/env/critical-runtime.ts`.
- Restricted dev-only fallback behavior to `NODE_ENV=development`.
- Enforced fail-fast behavior with explicit error codes for missing/insecure `AUTH_SECRET` and `DATABASE_URL` in runtime-sensitive auth paths.
- Enforced fail-fast behavior for `PII_ENCRYPTION_KEY` outside strict development and kept the dev-only fallback exclusively for `NODE_ENV=development`.
- Hardened `scripts/check-critical-secrets.mjs` to reject:
  - missing `AUTH_SECRET`, `DATABASE_URL`, `PII_ENCRYPTION_KEY`
  - weak `AUTH_SECRET` values under 32 bytes
  - known placeholder/default/hardcoded values
  - invalid PII keys that do not decode to the runtime-required 32-byte format
- Updated CI env defaults so the quality gate and QA snapshot server use non-placeholder strong values that satisfy the new checks.

## Impact
- Production-like runtimes no longer degrade silently when auth/PII secrets are absent or when login receives a local default database URL.
- Startup/runtime validation is now coherent across middleware, session signing, login, phone hashing, edge IP hashing, and the critical-secrets script.
- No schema or migration changes.
- No schema drift.

## Validation
Executed locally:
- `npm run test:win-stable -- src/__tests__/middleware.test.ts src/tests/auth/login-route.test.ts src/infra/pii/__tests__/crypto.test.ts src/__tests__/internal-auth-contract.test.ts src/tests/check-critical-secrets.test.ts src/infra/auth/__tests__/session.phase2.test.ts src/infra/pii/__tests__/phone.test.ts`
- `npm run guardrail:mvp-freeze`
- `npm run scope:pr-tests`
- `npm run lint:secrets-critical`
- `npm run lint`
- `npm run typecheck`
- `npm run routes:verify-security`
- `npm run routes:sync`
- `npm run test:coverage`
- `npm run build`
- `npm run db:verify`
- `node --import tsx scripts/guardrails-public-api.ts`

## Notes
- `src/ARCHITECTURE_COCKPIT.md` was updated to reflect the new `AUTH_SECRET` contract.
- The branch was created from current `origin/main`, so there are no merge conflicts with base at publish time.