### PR TITLE
[codex] Fix WhatsApp delivery callback persistence and outbound sid tracking

### DIFF
--- a/src/app/api/cockpit/conversations/[id]/message/route.ts
+++ b/src/app/api/cockpit/conversations/[id]/message/route.ts
@@ -6,6 +6,7 @@ import { makeRequestId } from '@/infra/http/request-trace';
 import { twilioProvider } from '@/providers/twilio.provider';
 import { logger } from '@/infra/logger';
 import { decryptString } from '@/infra/pii/crypto';
+import { whatsappOutboundService } from '@/modules/atendimento/whatsapp-outbound.service';
 
 function extractInboundMessageSid(metadata: Record<string, unknown> | null | undefined): string | null {
     if (!metadata) return null;
@@ -18,7 +19,7 @@ async function resolveRecipientPhone(
     tenantId: string,
     conversationId: string,
     phoneEncrypted: string,
-    requestId: string
+    requestId: string,
 ) {
     try {
         return decryptString(phoneEncrypted);
@@ -49,15 +50,15 @@ async function resolveRecipientPhone(
 
 export async function POST(
     request: NextRequest,
-    context: { params: Promise<{ id: string }> }
+    context: { params: Promise<{ id: string }> },
 ) {
     const requestId = makeRequestId(request);
-    
+
     const auth = await requireAdmin(request, { requestId });
     if (!auth.ok) return auth.response;
+
     const tenantId = auth.session.tenantId;
     const operatorId = (auth.session as any).userId ?? auth.session.sub;
-    let persistedMessageId: string | null = null;
     let activeConversationId: string | null = null;
 
     try {
@@ -69,18 +70,24 @@ export async function POST(
         } catch {
             return errorResponse(ErrorCode.VALIDATION_ERROR, 400, requestId, 'Invalid JSON body');
         }
-        const payloadText = typeof body?.text === 'string' ? body.text : body?.message;
 
+        const payloadText = typeof body?.text === 'string' ? body.text : body?.message;
         if (!payloadText || typeof payloadText !== 'string' || payloadText.trim() === '') {
             return errorResponse(ErrorCode.VALIDATION_ERROR, 400, requestId, 'Text is required and cannot be empty');
         }
 
         const text = payloadText.trim();
-
         const conversation = await conversationService.getConversationById(tenantId, conversationId);
         if (!conversation) {
             return errorResponse(ErrorCode.VALIDATION_ERROR, 404, requestId, 'Conversation not found');
         }
+
+        const plaintextPhone = await resolveRecipientPhone(
+            tenantId,
+            conversationId,
+            conversation.phoneEncrypted,
+            requestId,
+        );
 
         const outboundMetadata = {
             status: 'queued_for_send',
@@ -88,62 +95,36 @@ export async function POST(
             operatorId,
             channel: 'whatsapp',
         };
-        const conversationMessage = await conversationService.processOutboundMessage(
-            tenantId,
-            conversationId,
-            text,
-            'OPERATOR',
-            conversation.customerId || undefined,
-            outboundMetadata,
-            { advanceConversation: false }
-        );
-        persistedMessageId = conversationMessage.id;
-        const plaintextPhone = await resolveRecipientPhone(
-            tenantId,
-            conversationId,
-            conversation.phoneEncrypted,
-            requestId
-        );
 
         logger.info('TWILIO_OUTBOUND_START', {
             requestId,
             tenantId,
             conversationId,
-            conversationMessageId: conversationMessage.id,
             operatorId,
         });
 
-        const sendResult = await twilioProvider.sendMessageDetailed(tenantId, {
+        const trackedSend = await whatsappOutboundService.sendTrackedMessage({
+            tenantId,
+            conversationId,
             to: plaintextPhone,
-            body: text
+            message: text,
+            source: 'OPERATOR',
+            actorType: 'HUMAN',
+            customerId: conversation.customerId || undefined,
+            metadata: outboundMetadata,
         });
+        const conversationMessage = trackedSend.conversationMessage;
 
-        if (!sendResult.ok) {
-            const failedMetadata = {
-                ...outboundMetadata,
-                status: 'send_error',
-                errorCode: sendResult.errorCode,
-                errorMessage: sendResult.message,
-                providerStatusCode: sendResult.providerStatusCode ?? null,
-                failedAt: new Date().toISOString(),
-                retryable: sendResult.retryable ?? false,
-            };
-
-            await conversationService.updateMessageFields(
-                tenantId,
-                conversationMessage.id,
-                { metadata: failedMetadata, deliveryStatus: 'failed' }
-            );
-
-            logger.error('TWILIO_OUTBOUND_ERROR', new Error(sendResult.message), {
+        if (!trackedSend.ok) {
+            logger.error('TWILIO_OUTBOUND_ERROR', new Error(trackedSend.sendResult.message), {
                 requestId,
                 tenantId,
                 conversationId,
                 conversationMessageId: conversationMessage.id,
                 operatorId,
-                errorCode: sendResult.errorCode,
-                providerStatusCode: sendResult.providerStatusCode ?? null,
-                retryable: sendResult.retryable ?? false,
+                errorCode: trackedSend.sendResult.errorCode,
+                providerStatusCode: trackedSend.sendResult.providerStatusCode ?? null,
+                retryable: trackedSend.sendResult.retryable ?? false,
             });
 
             return errorResponse(
@@ -153,39 +134,24 @@ export async function POST(
                 'Failed to send message via Twilio',
                 {
                     conversationMessageId: conversationMessage.id,
-                    twilioErrorCode: sendResult.errorCode,
-                    providerStatusCode: sendResult.providerStatusCode ?? null,
-                }
+                    twilioErrorCode: trackedSend.sendResult.errorCode,
+                    providerStatusCode: trackedSend.sendResult.providerStatusCode ?? null,
+                },
             );
         }
-
-        const deliveredMetadata = {
-            ...outboundMetadata,
-            status: 'sent_ok',
-            twilioSid: sendResult.sid,
-            twilioStatus: sendResult.status,
-            providerStatusCode: sendResult.providerStatusCode,
-            attempts: sendResult.attempts,
-            sentAt: new Date().toISOString(),
-        };
-
-        const updatedMessage = await conversationService.updateMessageFields(
-            tenantId,
-            conversationMessage.id,
-            {
-                metadata: deliveredMetadata,
-                providerMessageId: sendResult.sid,
-                deliveryStatus: sendResult.status
-            }
-        );
 
         if (conversation.status !== 'operator_active') {
             await conversationService.updateConversationStatus(tenantId, conversationId, 'operator_active');
         }
 
         if (conversation.stage === 'NEW_LEAD') {
-            await conversationService.changeConversationStage(tenantId, conversationId, 'IN_ATTENDANCE', conversation.customerId ?? undefined);
-            
+            await conversationService.changeConversationStage(
+                tenantId,
+                conversationId,
+                'IN_ATTENDANCE',
+                conversation.customerId ?? undefined,
+            );
+
             const { publishOperationalEvent } = await import('@/lib/events/operational-event-bus');
             await publishOperationalEvent({
                 tenantId,
@@ -196,8 +162,8 @@ export async function POST(
                 payload: {
                     conversationId,
                     operatorId,
-                    stage: 'IN_ATTENDANCE'
-                }
+                    stage: 'IN_ATTENDANCE',
+                },
             });
         }
 
@@ -206,35 +172,25 @@ export async function POST(
             tenantId,
             conversationId,
             messageId: conversationMessage.id,
+            twilioSid: trackedSend.sendResult.sid,
+            deliveryStatus: trackedSend.normalizedStatus,
         });
 
         return NextResponse.json({
             ok: true,
-            data: updatedMessage ?? conversationMessage,
+            data: trackedSend.updatedMessage ?? conversationMessage,
             twilio: {
-                sid: sendResult.sid,
-                status: sendResult.status,
+                sid: trackedSend.sendResult.sid,
+                status: trackedSend.normalizedStatus,
+                providerStatus: trackedSend.sendResult.status,
             },
         });
     } catch (err: any) {
-        if (persistedMessageId) {
-            await conversationService.updateMessageFields(tenantId, persistedMessageId, {
-                metadata: {
-                    status: 'send_error',
-                    requestId,
-                    operatorId,
-                    failedAt: new Date().toISOString(),
-                    errorMessage: err instanceof Error ? err.message : String(err),
-                },
-                deliveryStatus: 'failed'
-            }).catch(() => undefined);
-        }
         logger.error('Failed to send operator message', err as Error, {
             requestId,
             tenantId,
             operatorId,
             conversationId: activeConversationId,
-            conversationMessageId: persistedMessageId,
         });
         return errorResponse(ErrorCode.UNKNOWN, 500, requestId, err.message);
     }

--- a/src/app/api/cockpit/conversations/[id]/quotes/[quoteId]/send/route.ts
+++ b/src/app/api/cockpit/conversations/[id]/quotes/[quoteId]/send/route.ts
@@ -1,37 +1,32 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { freightQuoteService } from '@/modules/atendimento/freight-quote.service';
-import { simulations } from '@/drizzle/schema';
-import { eq, and } from 'drizzle-orm';
-import { getDb } from '@/infra/db';
-import { conversationService } from '@/modules/atendimento/conversation.service';
 import { requireAdmin } from '@/infra/auth/guards';
 import { errorResponse } from '@/infra/http/error-response';
 import { makeRequestId } from '@/infra/http/request-trace';
-import { twilioProvider } from '@/providers/twilio.provider';
+import { conversationService } from '@/modules/atendimento/conversation.service';
 import { decryptString } from '@/infra/pii/crypto';
 import { domineIntakeService } from '@/domine/domine-intake.service';
 import { logger } from '@/infra/logger';
+import { whatsappOutboundService } from '@/modules/atendimento/whatsapp-outbound.service';
 
 export async function POST(
     request: NextRequest,
-    context: { params: Promise<{ id: string, quoteId: string }> }
+    context: { params: Promise<{ id: string, quoteId: string }> },
 ) {
     const requestId = makeRequestId(request);
-    
+
     const auth = await requireAdmin(request, { requestId });
     if (!auth.ok) return auth.response;
-    const { tenantId, userId: operatorId } = auth.session as any; 
+    const { tenantId, userId: operatorId } = auth.session as any;
 
     try {
         const { id: conversationId, quoteId } = await context.params;
-        
-        // Fetch Conversation
+
         const conversation = await conversationService.getConversationById(tenantId, conversationId);
         if (!conversation) {
             return errorResponse('NOT_FOUND' as any, 404, requestId, 'Conversation not found');
         }
 
-        // Fetch Quote
         const quote = await freightQuoteService.getQuoteById(tenantId, quoteId);
         if (!quote) {
             return errorResponse('NOT_FOUND' as any, 404, requestId, 'Quote not found');
@@ -42,45 +37,60 @@ export async function POST(
         }
 
         const plaintextPhone = decryptString(conversation.phoneEncrypted);
-        
-        // Format the message
-        let carrierName = quote.bestCarrier || 'Transportadora Parceira';
+        const carrierName = quote.bestCarrier || 'Transportadora Parceira';
         const formattedPrice = Number(quote.bestPrice).toFixed(2).replace('.', ',');
-        const deadline = quote.bestService || 'Consultar'; // usually bestService holds the SLA info or we can use generic text
-        
+        const deadline = quote.bestService || 'Consultar';
         const message = `🚚 *Cotação de Frete*\nEncontramos a melhor opção para você via ${carrierName}:\n\nValor: R$ ${formattedPrice}\nEstimativa (dias): ${deadline}\n\nPara seguirmos com o envio, basta confirmar!`;
 
-        // 1. Send via Twilio
-        const sent = await twilioProvider.sendMessage(tenantId, {
-            to: plaintextPhone,
-            body: message
-        });
-
-        if (!sent) {
-            return errorResponse('TWILIO_API_ERROR' as any, 502, requestId, 'Failed to send message via Twilio');
-        }
-
-        // 2. Persist to DB directly through service
-        const conversationMessage = await conversationService.processOutboundMessage(
+        const trackedSend = await whatsappOutboundService.sendTrackedMessage({
             tenantId,
             conversationId,
+            to: plaintextPhone,
             message,
-            'OPERATOR',
-            conversation.customerId || undefined, 
-            {
+            source: 'OPERATOR',
+            actorType: 'HUMAN',
+            customerId: conversation.customerId || undefined,
+            metadata: {
                 status: 'quote_sent',
                 quoteId: quote.id,
                 actorType: 'HUMAN',
-                messageType: 'TEXT'
-            }
-        );
+                messageType: 'TEXT',
+                requestId,
+                operatorId,
+            },
+        });
+
+        if (!trackedSend.ok) {
+            logger.error('QUOTE_SEND_TWILIO_ERROR', new Error(trackedSend.sendResult.message), {
+                requestId,
+                tenantId,
+                conversationId,
+                quoteId,
+                conversationMessageId: trackedSend.conversationMessage.id,
+                errorCode: trackedSend.sendResult.errorCode,
+                providerStatusCode: trackedSend.sendResult.providerStatusCode ?? null,
+            });
+
+            return errorResponse('TWILIO_API_ERROR' as any, 502, requestId, 'Failed to send message via Twilio', {
+                conversationMessageId: trackedSend.conversationMessage.id,
+                twilioErrorCode: trackedSend.sendResult.errorCode,
+                providerStatusCode: trackedSend.sendResult.providerStatusCode ?? null,
+            });
+        }
+
+        await conversationService.markConversationWaitingCustomer(tenantId, conversationId);
+
         if (conversation.stage === 'NEW_LEAD' || conversation.stage === 'IN_ATTENDANCE') {
-            await conversationService.changeConversationStage(tenantId, conversationId, 'QUOTED', conversation.customerId ?? undefined);
+            await conversationService.changeConversationStage(
+                tenantId,
+                conversationId,
+                'QUOTED',
+                conversation.customerId ?? undefined,
+            );
         }
 
         await freightQuoteService.sendQuote(tenantId, quoteId);
 
-        // 3. Emit QUOTE_SENT
         void domineIntakeService.publish({
             tenantId,
             type: 'QUOTE_SENT',
@@ -89,11 +99,22 @@ export async function POST(
                 quoteId: quote.id,
                 conversationId,
                 operatorId,
-                customerId: conversation.customerId
-            }
-        }).catch(e => logger.warn('Failed to emit QUOTE_SENT', { error: e.message }));
+                customerId: conversation.customerId,
+                messageId: trackedSend.conversationMessage.id,
+                sid: trackedSend.sendResult.sid,
+                deliveryStatus: trackedSend.normalizedStatus,
+            },
+        }).catch((error) => logger.warn('Failed to emit QUOTE_SENT', { error: error.message }));
 
-        return NextResponse.json({ ok: true, data: conversationMessage });
+        return NextResponse.json({
+            ok: true,
+            data: trackedSend.updatedMessage ?? trackedSend.conversationMessage,
+            twilio: {
+                sid: trackedSend.sendResult.sid,
+                status: trackedSend.normalizedStatus,
+                providerStatus: trackedSend.sendResult.status,
+            },
+        });
     } catch (err: any) {
         logger.error('Failed to send freight quote to customer', err as Error, { requestId });
         return errorResponse('INTERNAL_ERROR' as any, 500, requestId, err.message);

--- a/src/app/api/whatsapp/status/__tests__/route.test.ts
+++ b/src/app/api/whatsapp/status/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { verifyTwilioSignature } from '@/lib/security/webhook-verifier';
+import { rateLimiter } from '@/infra/security/rate-limiter';
+import { whatsappDeliveryStatusService } from '@/modules/atendimento/whatsapp-delivery-status.service';
+
+vi.mock('@/infra/security/rate-limiter', () => ({
+    rateLimiter: { limit: vi.fn() },
+    hashRateLimitKeyForLog: vi.fn().mockReturnValue('hashed-key'),
+}));
+vi.mock('@/lib/security/webhook-verifier', () => ({
+    verifyTwilioSignature: vi.fn(),
+}));
+vi.mock('@/modules/atendimento/whatsapp-delivery-status.service', () => ({
+    whatsappDeliveryStatusService: {
+        updateDeliveryStatus: vi.fn(),
+    },
+}));
+vi.mock('@/infra/logger', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@/infra/log/logger', () => ({
+    structuredLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('POST /api/whatsapp/status', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env = { ...originalEnv, NODE_ENV: 'production', APP_URL: 'http://localhost:3000' } as any;
+        vi.mocked(verifyTwilioSignature).mockReturnValue(true);
+        vi.mocked(rateLimiter.limit).mockResolvedValue({ allowed: true } as any);
+        vi.mocked(whatsappDeliveryStatusService.updateDeliveryStatus).mockResolvedValue({
+            outcome: 'updated',
+            providerStatus: 'delivered',
+            normalizedStatus: 'delivered',
+            messageId: 'msg-1',
+            conversationId: 'conv-1',
+        } as any);
+    });
+
+    it('returns empty xml for invalid content type', async () => {
+        const req = new NextRequest('http://localhost:3000/api/whatsapp/status', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ MessageSid: 'SM123' }),
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('<Response></Response>');
+        expect(whatsappDeliveryStatusService.updateDeliveryStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid signatures in production', async () => {
+        vi.mocked(verifyTwilioSignature).mockReturnValue(false);
+        const body = new URLSearchParams({ MessageSid: 'SM123', MessageStatus: 'delivered' }).toString();
+        const req = new NextRequest('http://localhost:3000/api/whatsapp/status', {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                'x-twilio-signature': 'invalid',
+            },
+            body,
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(401);
+        expect(whatsappDeliveryStatusService.updateDeliveryStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns empty xml when required fields are missing', async () => {
+        const req = new NextRequest('http://localhost:3000/api/whatsapp/status', {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ MessageSid: 'SM123' }).toString(),
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('<Response></Response>');
+        expect(whatsappDeliveryStatusService.updateDeliveryStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns empty xml when rate limited', async () => {
+        vi.mocked(rateLimiter.limit).mockResolvedValue({ allowed: false } as any);
+        const req = new NextRequest('http://localhost:3000/api/whatsapp/status', {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ MessageSid: 'SM123', MessageStatus: 'delivered' }).toString(),
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('<Response></Response>');
+        expect(whatsappDeliveryStatusService.updateDeliveryStatus).not.toHaveBeenCalled();
+    });
+
+    it('delegates a valid callback to the delivery status service', async () => {
+        const req = new NextRequest('http://localhost:3000/api/whatsapp/status', {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                MessageSid: 'SM123',
+                MessageStatus: 'failed',
+                ErrorCode: '30003',
+                ErrorMessage: 'Blocked destination',
+            }).toString(),
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+        expect(whatsappDeliveryStatusService.updateDeliveryStatus).toHaveBeenCalledWith(expect.objectContaining({
+            messageSid: 'SM123',
+            providerStatus: 'failed',
+            providerErrorCode: '30003',
+            providerErrorMessage: 'Blocked destination',
+        }));
+    });
+
+    it('returns 200 when the sid does not exist', async () => {
+        vi.mocked(whatsappDeliveryStatusService.updateDeliveryStatus).mockResolvedValue({
+            outcome: 'message_not_found',
+            providerStatus: 'delivered',
+            normalizedStatus: 'delivered',
+        } as any);
+
+        const req = new NextRequest('http://localhost:3000/api/whatsapp/status', {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ MessageSid: 'SM404', MessageStatus: 'delivered' }).toString(),
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('<Response></Response>');
+    });
+});

--- a/src/app/api/whatsapp/status/route.ts
+++ b/src/app/api/whatsapp/status/route.ts
@@ -1,188 +1,100 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/infra/db';
-import { conversationMessages, operationalEvents } from '@/drizzle/schema';
-import { eq, and } from 'drizzle-orm';
 import { logger } from '@/infra/logger';
-import { randomUUID } from 'crypto';
+import { structuredLogger } from '@/infra/log/logger';
+import { rateLimiter, hashRateLimitKeyForLog } from '@/infra/security/rate-limiter';
+import { verifyTwilioSignature } from '@/lib/security/webhook-verifier';
+import { whatsappDeliveryStatusService } from '@/modules/atendimento/whatsapp-delivery-status.service';
 
-// Status weight for idempotent forward-only transitions
-const STATUS_WEIGHT: Record<string, number> = {
-    queued: 0,
-    sent: 1,
-    delivered: 2,
-    read: 3,
-    failed: 4, // failed can override any status
-};
-
-function shouldUpdate(current: string | null, incoming: string): boolean {
-    if (!current) return true;
-    if (incoming === 'failed') return true; // failed always wins
-    return (STATUS_WEIGHT[incoming] ?? 0) > (STATUS_WEIGHT[current] ?? -1);
+function xmlAck(status: number = 200) {
+    return new NextResponse('<Response></Response>', {
+        status,
+        headers: { 'Content-Type': 'text/xml' },
+    });
 }
 
-// Handles Twilio Status Callbacks (sent, delivered, read, failed)
+function parseFormPayload(rawBody: string): Record<string, string> {
+    const params = new URLSearchParams(rawBody);
+    const payload: Record<string, string> = {};
+    params.forEach((value, key) => {
+        payload[key] = value;
+    });
+    return payload;
+}
+
 export async function POST(request: NextRequest) {
     try {
         const contentType = request.headers.get('content-type') || '';
         if (!contentType.includes('application/x-www-form-urlencoded')) {
-            return new NextResponse('<Response></Response>', {
-                status: 200,
-                headers: { 'Content-Type': 'text/xml' },
+            structuredLogger.warn('whatsapp_status_invalid_content_type', {
+                route: '/api/whatsapp/status',
+                contentType,
             });
+            return xmlAck();
         }
 
         const rawBody = await request.text();
-        const params = new URLSearchParams(rawBody);
-        const payload: Record<string, string> = {};
-        params.forEach((value, key) => { payload[key] = value; });
+        const payload = parseFormPayload(rawBody);
+        const messageSid = payload.MessageSid?.trim();
+        const providerStatus = payload.MessageStatus?.trim();
+        const providerErrorCode = payload.ErrorCode?.trim() || null;
+        const providerErrorMessage = payload.ErrorMessage?.trim() || payload.ChannelStatusMessage?.trim() || null;
+        const twilioUrl = process.env.APP_URL
+            ? `${process.env.APP_URL}/api/whatsapp/status`
+            : `https://${request.headers.get('host')}/api/whatsapp/status`;
 
-        // Validate Twilio Signature
-        const twilioUrl = process.env.APP_URL ? `${process.env.APP_URL}/api/whatsapp/status` : `https://${request.headers.get('host')}/api/whatsapp/status`;
-        
-        const { structuredLogger } = await import('@/infra/log/logger');
-        structuredLogger.info('webhook_status_total', { eventType: 'whatsapp', payload });
-        const { verifyTwilioSignature } = await import('@/lib/security/webhook-verifier');
-        
+        structuredLogger.info('whatsapp_status_webhook_received', {
+            route: '/api/whatsapp/status',
+            messageSid: messageSid ?? null,
+            providerStatus: providerStatus ?? null,
+            hasProviderError: Boolean(providerErrorCode || providerErrorMessage),
+        });
+
         if (process.env.NODE_ENV === 'production' && !verifyTwilioSignature(request, rawBody, payload, twilioUrl)) {
             logger.warn('twilio_status_callback_invalid_signature', { route: '/api/whatsapp/status' });
-            return new NextResponse('<Response></Response>', {
-                status: 401,
-                headers: { 'Content-Type': 'text/xml' },
-            });
+            return xmlAck(401);
         }
 
-        const messageSid = payload.MessageSid;
-        const messageStatus = payload.MessageStatus;
-
-        if (!messageSid || !messageStatus) {
-            return new NextResponse('<Response></Response>', {
-                status: 200, // Twilio requires 200 OK regardless
-                headers: { 'Content-Type': 'text/xml' },
+        if (!messageSid || !providerStatus) {
+            structuredLogger.warn('whatsapp_status_missing_required_fields', {
+                route: '/api/whatsapp/status',
+                hasMessageSid: Boolean(messageSid),
+                hasProviderStatus: Boolean(providerStatus),
             });
+            return xmlAck();
         }
 
-        const { rateLimiter, hashRateLimitKeyForLog } = await import('@/infra/security/rate-limiter');
         const rlKey = `msg:${messageSid}`;
         const rlDecision = await rateLimiter.limit('whatsapp_status', rlKey, { windowSec: 10, max: 20 });
-        
         if (!rlDecision.allowed) {
             logger.warn('whatsapp_status_rate_limited', {
                 route: '/api/whatsapp/status',
                 messageSid,
-                keyHash: hashRateLimitKeyForLog(rlKey)
+                keyHash: hashRateLimitKeyForLog(rlKey),
             });
-            return new NextResponse('<Response></Response>', {
-                status: 200,
-                headers: { 'Content-Type': 'text/xml' },
-            });
+            return xmlAck();
         }
 
-        const db = await getDb();
-
-        const [existing] = await db
-            .select()
-            .from(conversationMessages)
-            .where(eq(conversationMessages.providerMessageId, messageSid))
-            .limit(1);
-
-        // If we found the message tracked explicitly by providerMessageId:
-        if (existing) {
-            let mappedStatus: 'queued' | 'sent' | 'delivered' | 'read' | 'failed' = 'sent';
-            switch (messageStatus) {
-                case 'queued':
-                case 'accepted':
-                    mappedStatus = 'queued';
-                    break;
-                case 'sent':
-                    mappedStatus = 'sent';
-                    break;
-                case 'delivered':
-                    mappedStatus = 'delivered';
-                    break;
-                case 'read':
-                    mappedStatus = 'read';
-                    break;
-                case 'failed':
-                case 'undelivered':
-                    mappedStatus = 'failed';
-                    break;
-                default:
-                    mappedStatus = 'sent'; // Fallback
-            }
-
-            // Idempotent: reject backward status transitions
-            if (!shouldUpdate(existing.deliveryStatus, mappedStatus)) {
-                logger.info('twilio_status_callback_skipped_backward', {
-                    messageSid,
-                    currentStatus: existing.deliveryStatus,
-                    incomingStatus: mappedStatus,
-                });
-                return new NextResponse('<Response></Response>', {
-                    status: 200,
-                    headers: { 'Content-Type': 'text/xml' },
-                });
-            }
-
-            const previousStatus = existing.deliveryStatus;
-
-            await db.transaction(async (tx) => {
-                // Tenant-scoped update
-                await tx
-                    .update(conversationMessages)
-                    .set({
-                        deliveryStatus: mappedStatus,
-                    })
-                    .where(and(
-                        eq(conversationMessages.id, existing.id),
-                        eq(conversationMessages.tenantId, existing.tenantId)
-                    ));
-
-                if (mappedStatus === 'failed') {
-                    const { conversations } = await import('@/drizzle/schema');
-                    await tx
-                        .update(conversations)
-                        .set({ status: 'failed_delivery' })
-                        .where(and(
-                            eq(conversations.id, existing.conversationId),
-                            eq(conversations.tenantId, existing.tenantId)
-                        ));
-                }
-
-                // Audit: emit operational event for status change
-                await tx.insert(operationalEvents).values({
-                    id: randomUUID(),
-                    tenantId: existing.tenantId,
-                    eventType: 'delivery_status_changed',
-                    eventDomain: 'OPERATIONS',
-                    payload: {
-                        messageId: existing.id,
-                        conversationId: existing.conversationId,
-                        messageSid,
-                        previousStatus,
-                        newStatus: mappedStatus,
-                        twilioStatus: messageStatus,
-                    },
-                });
-            });
-
-            logger.info('twilio_status_callback_processed', {
-                messageSid,
-                messageStatus,
-                mappedStatus,
-                previousStatus,
-                messageId: existing.id,
-            });
-        }
-
-        return new NextResponse('<Response></Response>', {
-            status: 200,
-            headers: { 'Content-Type': 'text/xml' },
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid,
+            providerStatus,
+            callbackReceivedAt: new Date(),
+            providerErrorCode,
+            providerErrorMessage,
         });
+
+        structuredLogger.info('whatsapp_status_webhook_processed', {
+            route: '/api/whatsapp/status',
+            messageSid,
+            providerStatus,
+            normalizedStatus: result.normalizedStatus ?? null,
+            outcome: result.outcome,
+            messageId: result.messageId ?? null,
+            conversationId: result.conversationId ?? null,
+        });
+
+        return xmlAck();
     } catch (error) {
         logger.error('twilio_status_callback_failed', error as Error);
-        return new NextResponse('<Response></Response>', {
-            status: 200,
-            headers: { 'Content-Type': 'text/xml' },
-        });
+        return xmlAck();
     }
 }

--- a/src/modules/atendimento/__tests__/whatsapp-delivery-status.service.test.ts
+++ b/src/modules/atendimento/__tests__/whatsapp-delivery-status.service.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { conversationService } from '@/modules/atendimento/conversation.service';
+import { ecosystemEventsService } from '@/services/ecosystem-events.service';
+import { getDb } from '@/infra/db';
+import {
+    whatsappDeliveryStatusService,
+    normalizeTwilioDeliveryStatus,
+    resolveInitialOutboundDeliveryStatus,
+    classifyDeliveryStatusTransition,
+} from '../whatsapp-delivery-status.service';
+
+vi.mock('@/infra/db', () => ({ getDb: vi.fn() }));
+vi.mock('@/modules/atendimento/conversation.service', () => ({
+    conversationService: {
+        getMessageByProviderMessageId: vi.fn(),
+    },
+}));
+vi.mock('@/services/ecosystem-events.service', () => ({
+    ecosystemEventsService: {
+        emitEvent: vi.fn().mockResolvedValue('evt-1'),
+    },
+}));
+vi.mock('@/infra/logger', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@/infra/log/logger', () => ({
+    structuredLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('whatsappDeliveryStatusService', () => {
+    const tx: any = {
+        update: vi.fn(() => tx),
+        set: vi.fn(() => tx),
+        where: vi.fn().mockResolvedValue(undefined),
+        insert: vi.fn(() => tx),
+        values: vi.fn().mockResolvedValue(undefined),
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getDb).mockResolvedValue({
+            transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<void>) => callback(tx)),
+        } as any);
+    });
+
+    it('normalizes provider statuses into the internal vocabulary', () => {
+        expect(normalizeTwilioDeliveryStatus('accepted')).toBe('queued');
+        expect(normalizeTwilioDeliveryStatus('sending')).toBe('sent');
+        expect(normalizeTwilioDeliveryStatus('undelivered')).toBe('failed');
+        expect(resolveInitialOutboundDeliveryStatus('')).toBe('queued');
+        expect(classifyDeliveryStatusTransition('sent', 'delivered')).toBe('apply');
+        expect(classifyDeliveryStatusTransition('delivered', 'sent')).toBe('out_of_order');
+    });
+
+    it('updates an outbound message to delivered', async () => {
+        vi.mocked(conversationService.getMessageByProviderMessageId).mockResolvedValue({
+            id: 'msg-1',
+            tenantId: 'tenant-1',
+            conversationId: 'conv-1',
+            direction: 'outbound',
+            source: 'OPERATOR',
+            message: 'Oi',
+            metadata: { status: 'sent_ok' },
+            providerMessageId: 'SM123',
+            deliveryStatus: 'sent',
+            createdAt: new Date(),
+        } as any);
+
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM123',
+            providerStatus: 'delivered',
+            callbackReceivedAt: new Date('2026-04-13T12:00:00.000Z'),
+        });
+
+        expect(result).toMatchObject({
+            outcome: 'updated',
+            normalizedStatus: 'delivered',
+            previousStatus: 'sent',
+            messageId: 'msg-1',
+        });
+        expect(tx.set).toHaveBeenCalledWith(expect.objectContaining({ deliveryStatus: 'delivered' }));
+        expect(tx.values).toHaveBeenCalledWith(expect.objectContaining({
+            eventType: 'delivery_status_changed',
+            payload: expect.objectContaining({ sid: 'SM123', normalizedStatus: 'delivered' }),
+        }));
+        expect(ecosystemEventsService.emitEvent).not.toHaveBeenCalled();
+    });
+
+    it('updates failed status and publishes MESSAGE_DELIVERY_FAILED', async () => {
+        vi.mocked(conversationService.getMessageByProviderMessageId).mockResolvedValue({
+            id: 'msg-2',
+            tenantId: 'tenant-2',
+            conversationId: 'conv-2',
+            direction: 'outbound',
+            source: 'OPERATOR',
+            message: 'Teste',
+            metadata: null,
+            providerMessageId: 'SM234',
+            deliveryStatus: 'sent',
+            createdAt: new Date(),
+        } as any);
+
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM234',
+            providerStatus: 'failed',
+            providerErrorCode: '30003',
+            providerErrorMessage: 'Blocked destination',
+            callbackReceivedAt: new Date('2026-04-13T12:10:00.000Z'),
+        });
+
+        expect(result).toMatchObject({ outcome: 'updated', normalizedStatus: 'failed' });
+        expect(tx.values).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            eventType: 'delivery_status_changed',
+        }));
+        expect(tx.values).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            eventType: 'MESSAGE_DELIVERY_FAILED',
+            payload: expect.objectContaining({
+                sid: 'SM234',
+                providerStatus: 'failed',
+                normalizedStatus: 'failed',
+                providerErrorCode: '30003',
+            }),
+        }));
+        expect(ecosystemEventsService.emitEvent).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 'tenant-2',
+            type: 'message_delivery_failed',
+            entityId: 'msg-2',
+            payload: expect.objectContaining({ sid: 'SM234' }),
+        }));
+    });
+
+    it('treats undelivered as failed and keeps provider status in the payload', async () => {
+        vi.mocked(conversationService.getMessageByProviderMessageId).mockResolvedValue({
+            id: 'msg-3',
+            tenantId: 'tenant-3',
+            conversationId: 'conv-3',
+            direction: 'outbound',
+            source: 'OPERATOR',
+            message: 'Teste',
+            metadata: null,
+            providerMessageId: 'SM345',
+            deliveryStatus: 'sent',
+            createdAt: new Date(),
+        } as any);
+
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM345',
+            providerStatus: 'undelivered',
+            providerErrorMessage: 'Carrier rejected',
+        });
+
+        expect(result.normalizedStatus).toBe('failed');
+        expect(tx.values).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            payload: expect.objectContaining({ providerStatus: 'undelivered' }),
+        }));
+    });
+
+    it('is idempotent for duplicate callbacks', async () => {
+        vi.mocked(conversationService.getMessageByProviderMessageId).mockResolvedValue({
+            id: 'msg-4',
+            tenantId: 'tenant-4',
+            conversationId: 'conv-4',
+            direction: 'outbound',
+            source: 'OPERATOR',
+            message: 'Teste',
+            metadata: null,
+            providerMessageId: 'SM456',
+            deliveryStatus: 'delivered',
+            createdAt: new Date(),
+        } as any);
+
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM456',
+            providerStatus: 'delivered',
+        });
+
+        expect(result.outcome).toBe('duplicate');
+        expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it('returns message_not_found when the sid does not exist', async () => {
+        vi.mocked(conversationService.getMessageByProviderMessageId).mockResolvedValue(undefined);
+
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM999',
+            providerStatus: 'delivered',
+        });
+
+        expect(result).toMatchObject({ outcome: 'message_not_found', normalizedStatus: 'delivered' });
+        expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it('ignores unknown statuses explicitly', async () => {
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM777',
+            providerStatus: 'mystery_status',
+        });
+
+        expect(result).toEqual({ outcome: 'ignored_unknown_status', providerStatus: 'mystery_status' });
+        expect(conversationService.getMessageByProviderMessageId).not.toHaveBeenCalled();
+    });
+
+    it('ignores out-of-order callbacks', async () => {
+        vi.mocked(conversationService.getMessageByProviderMessageId).mockResolvedValue({
+            id: 'msg-5',
+            tenantId: 'tenant-5',
+            conversationId: 'conv-5',
+            direction: 'outbound',
+            source: 'OPERATOR',
+            message: 'Teste',
+            metadata: null,
+            providerMessageId: 'SM567',
+            deliveryStatus: 'delivered',
+            createdAt: new Date(),
+        } as any);
+
+        const result = await whatsappDeliveryStatusService.updateDeliveryStatus({
+            messageSid: 'SM567',
+            providerStatus: 'sent',
+        });
+
+        expect(result.outcome).toBe('ignored_out_of_order');
+        expect(getDb).not.toHaveBeenCalled();
+    });
+});

--- a/src/modules/atendimento/__tests__/whatsapp-outbound.service.test.ts
+++ b/src/modules/atendimento/__tests__/whatsapp-outbound.service.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { conversationService } from '@/modules/atendimento/conversation.service';
+import { twilioProvider } from '@/providers/twilio.provider';
+import { whatsappOutboundService } from '../whatsapp-outbound.service';
+
+vi.mock('@/modules/atendimento/conversation.service', () => ({
+    conversationService: {
+        processOutboundMessage: vi.fn(),
+        updateMessageFields: vi.fn(),
+    },
+}));
+vi.mock('@/providers/twilio.provider', () => ({
+    twilioProvider: {
+        sendMessageDetailed: vi.fn(),
+    },
+}));
+
+describe('whatsappOutboundService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(conversationService.processOutboundMessage).mockResolvedValue({
+            id: 'msg-1',
+            tenantId: 'tenant-1',
+            conversationId: 'conv-1',
+            direction: 'outbound',
+            source: 'OPERATOR',
+            message: 'Oi',
+            metadata: { status: 'queued_for_send' },
+            providerMessageId: null,
+            deliveryStatus: 'queued',
+            createdAt: new Date(),
+        } as any);
+        vi.mocked(conversationService.updateMessageFields).mockResolvedValue({ id: 'msg-1' } as any);
+    });
+
+    it('persists sid and normalizes accepted into queued on the initial outbound send', async () => {
+        vi.mocked(twilioProvider.sendMessageDetailed).mockResolvedValue({
+            ok: true,
+            sid: 'SM123',
+            status: 'accepted',
+            to: '+5511999999999',
+            from: 'whatsapp:+5511000000000',
+            attempts: 1,
+            providerStatusCode: 201,
+        });
+
+        const result = await whatsappOutboundService.sendTrackedMessage({
+            tenantId: 'tenant-1',
+            conversationId: 'conv-1',
+            to: '+5511999999999',
+            message: 'Oi',
+            source: 'OPERATOR',
+            actorType: 'HUMAN',
+            metadata: { requestId: 'req-1' },
+        });
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) throw new Error('expected success');
+        expect(result.normalizedStatus).toBe('queued');
+        expect(conversationService.updateMessageFields).toHaveBeenCalledWith('tenant-1', 'msg-1', expect.objectContaining({
+            providerMessageId: 'SM123',
+            deliveryStatus: 'queued',
+        }));
+    });
+
+    it('normalizes sending into sent on the initial outbound send', async () => {
+        vi.mocked(twilioProvider.sendMessageDetailed).mockResolvedValue({
+            ok: true,
+            sid: 'SM124',
+            status: 'sending',
+            to: '+5511999999999',
+            from: 'whatsapp:+5511000000000',
+            attempts: 1,
+            providerStatusCode: 201,
+        });
+
+        const result = await whatsappOutboundService.sendTrackedMessage({
+            tenantId: 'tenant-1',
+            conversationId: 'conv-1',
+            to: '+5511999999999',
+            message: 'Oi',
+            source: 'OPERATOR',
+            actorType: 'HUMAN',
+        });
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) throw new Error('expected success');
+        expect(result.normalizedStatus).toBe('sent');
+        expect(conversationService.updateMessageFields).toHaveBeenCalledWith('tenant-1', 'msg-1', expect.objectContaining({
+            providerMessageId: 'SM124',
+            deliveryStatus: 'sent',
+        }));
+    });
+
+    it('marks the message as failed when Twilio returns an error', async () => {
+        vi.mocked(twilioProvider.sendMessageDetailed).mockResolvedValue({
+            ok: false,
+            errorCode: 'TWILIO_API_ERROR',
+            message: 'upstream error',
+            to: '+5511999999999',
+            attempts: 1,
+            providerStatusCode: 500,
+            retryable: true,
+        });
+
+        const result = await whatsappOutboundService.sendTrackedMessage({
+            tenantId: 'tenant-1',
+            conversationId: 'conv-1',
+            to: '+5511999999999',
+            message: 'Oi',
+            source: 'OPERATOR',
+            actorType: 'HUMAN',
+        });
+
+        expect(result.ok).toBe(false);
+        expect(conversationService.updateMessageFields).toHaveBeenCalledWith('tenant-1', 'msg-1', expect.objectContaining({
+            deliveryStatus: 'failed',
+        }));
+    });
+});

--- a/src/modules/atendimento/conversation.repository.ts
+++ b/src/modules/atendimento/conversation.repository.ts
@@ -13,6 +13,7 @@ import {
     type ConversationRecord,
     type ConversationMessageRecord,
     type ConversationStatusType,
+    type MessageDeliveryStatusType,
 } from '@/drizzle/schema';
 
 export interface ConversationListFilter {
@@ -322,13 +323,26 @@ export const conversationRepository = {
             .orderBy(asc(conversationMessages.createdAt), asc(conversationMessages.id));
     },
 
+    async getConversationMessageByProviderMessageId(messageSid: string): Promise<ConversationMessageRecord | undefined> {
+        const normalizedMessageSid = messageSid.trim();
+        if (!normalizedMessageSid) return undefined;
+
+        const db = await getDb();
+        const [message] = await db.select()
+            .from(conversationMessages)
+            .where(eq(conversationMessages.providerMessageId, normalizedMessageSid))
+            .limit(1);
+
+        return message;
+    },
+
     async updateConversationMessageFields(
         tenantId: string,
         messageId: string,
         fields: {
             metadata?: Record<string, any>;
             providerMessageId?: string | null;
-            deliveryStatus?: string | null;
+            deliveryStatus?: MessageDeliveryStatusType | null;
         }
     ): Promise<ConversationMessageRecord | undefined> {
         const db = await getDb();

--- a/src/modules/atendimento/conversation.service.ts
+++ b/src/modules/atendimento/conversation.service.ts
@@ -1,5 +1,10 @@
 import { conversationRepository, type ConversationListFilter } from './conversation.repository';
-import { type ConversationRecord, type ConversationMessageRecord, type ConversationStatusType } from '@/drizzle/schema';
+import {
+    type ConversationRecord,
+    type ConversationMessageRecord,
+    type ConversationStatusType,
+    type MessageDeliveryStatusType,
+} from '@/drizzle/schema';
 import { publishOperationalEvent } from '@/lib/events/operational-event-bus';
 import { ecosystemEventsService } from '@/services/ecosystem-events.service';
 
@@ -30,6 +35,10 @@ export const conversationService = {
 
     async getConversationMessages(tenantId: string, conversationId: string): Promise<ConversationMessageRecord[]> {
         return conversationRepository.getConversationMessages(tenantId, conversationId);
+    },
+
+    async getMessageByProviderMessageId(messageSid: string): Promise<ConversationMessageRecord | undefined> {
+        return conversationRepository.getConversationMessageByProviderMessageId(messageSid);
     },
 
     async hasRecentOperatorMessage(tenantId: string, conversationId: string, minutes: number = 15): Promise<boolean> {
@@ -73,7 +82,7 @@ export const conversationService = {
         fields: {
             metadata?: Record<string, any>;
             providerMessageId?: string | null;
-            deliveryStatus?: string | null;
+            deliveryStatus?: MessageDeliveryStatusType | null;
         }
     ): Promise<ConversationMessageRecord | undefined> {
         return conversationRepository.updateConversationMessageFields(tenantId, messageId, fields);

--- a/src/modules/atendimento/whatsapp-delivery-status.service.ts
+++ b/src/modules/atendimento/whatsapp-delivery-status.service.ts
@@ -1,0 +1,376 @@
+import { randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { getDb } from '@/infra/db';
+import {
+    conversationMessages,
+    conversations,
+    operationalEvents,
+    type ConversationMessageRecord,
+    type MessageDeliveryStatusType,
+} from '@/drizzle/schema';
+import { logger } from '@/infra/logger';
+import { structuredLogger } from '@/infra/log/logger';
+import { conversationService } from './conversation.service';
+import { ecosystemEventsService } from '@/services/ecosystem-events.service';
+
+const TWILIO_STATUS_MAP: Record<string, MessageDeliveryStatusType> = {
+    queued: 'queued',
+    accepted: 'queued',
+    sending: 'sent',
+    sent: 'sent',
+    delivered: 'delivered',
+    read: 'read',
+    failed: 'failed',
+    undelivered: 'failed',
+};
+
+const ALLOWED_STATUS_TRANSITIONS: Record<MessageDeliveryStatusType, readonly MessageDeliveryStatusType[]> = {
+    queued: ['sent', 'delivered', 'read', 'failed'],
+    sent: ['delivered', 'read', 'failed'],
+    delivered: ['read'],
+    read: [],
+    failed: [],
+};
+
+export type TwilioDeliveryStatus = keyof typeof TWILIO_STATUS_MAP;
+
+export interface DeliveryTrackingMetadataUpdate {
+    sid: string;
+    providerStatus: string | null;
+    normalizedStatus: MessageDeliveryStatusType;
+    statusUpdatedAt: Date;
+    providerErrorCode?: string | null;
+    providerErrorMessage?: string | null;
+}
+
+export interface UpdateDeliveryStatusParams {
+    messageSid: string;
+    providerStatus: string;
+    callbackReceivedAt?: Date;
+    providerErrorCode?: string | null;
+    providerErrorMessage?: string | null;
+}
+
+export interface UpdateDeliveryStatusResult {
+    outcome:
+        | 'updated'
+        | 'duplicate'
+        | 'ignored_out_of_order'
+        | 'ignored_unknown_status'
+        | 'message_not_found'
+        | 'ignored_non_outbound';
+    tenantId?: string;
+    conversationId?: string | null;
+    messageId?: string;
+    normalizedStatus?: MessageDeliveryStatusType;
+    previousStatus?: MessageDeliveryStatusType | null;
+    providerStatus: string;
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asMetadataRecord(value: unknown): Record<string, unknown> {
+    return isRecord(value) ? { ...value } : {};
+}
+
+function normalizeStoredDeliveryStatus(value: string | null | undefined): MessageDeliveryStatusType | null {
+    const normalized = normalizeOptionalString(value);
+    if (!normalized) return null;
+    return Object.values(TWILIO_STATUS_MAP).includes(normalized as MessageDeliveryStatusType)
+        ? (normalized as MessageDeliveryStatusType)
+        : null;
+}
+
+export function normalizeTwilioDeliveryStatus(value: string | null | undefined): MessageDeliveryStatusType | null {
+    const normalized = normalizeOptionalString(value)?.toLowerCase();
+    return normalized ? TWILIO_STATUS_MAP[normalized] ?? null : null;
+}
+
+export function resolveInitialOutboundDeliveryStatus(value: string | null | undefined): MessageDeliveryStatusType {
+    return normalizeTwilioDeliveryStatus(value) ?? 'queued';
+}
+
+export function classifyDeliveryStatusTransition(
+    current: string | null | undefined,
+    incoming: MessageDeliveryStatusType,
+): 'apply' | 'duplicate' | 'out_of_order' {
+    const normalizedCurrent = normalizeStoredDeliveryStatus(current);
+    if (!normalizedCurrent) return 'apply';
+    if (normalizedCurrent === incoming) return 'duplicate';
+
+    return ALLOWED_STATUS_TRANSITIONS[normalizedCurrent].includes(incoming) ? 'apply' : 'out_of_order';
+}
+
+export function mergeMessageDeliveryTrackingMetadata(
+    existingMetadata: Record<string, unknown> | null | undefined,
+    update: DeliveryTrackingMetadataUpdate,
+): Record<string, unknown> {
+    const metadata = asMetadataRecord(existingMetadata);
+    const deliveryTracking = asMetadataRecord(metadata.deliveryTracking);
+    const statusUpdatedAt = update.statusUpdatedAt.toISOString();
+
+    return {
+        ...metadata,
+        twilioSid: update.sid,
+        twilioStatus: update.providerStatus,
+        twilioNormalizedStatus: update.normalizedStatus,
+        twilioStatusUpdatedAt: statusUpdatedAt,
+        twilioErrorCode: update.providerErrorCode ?? null,
+        twilioErrorMessage: update.providerErrorMessage ?? null,
+        deliveryTracking: {
+            ...deliveryTracking,
+            provider: 'twilio',
+            sid: update.sid,
+            providerStatus: update.providerStatus,
+            normalizedStatus: update.normalizedStatus,
+            lastUpdatedAt: statusUpdatedAt,
+            providerErrorCode: update.providerErrorCode ?? null,
+            providerErrorMessage: update.providerErrorMessage ?? null,
+        },
+    };
+}
+
+function buildFailureEventPayload(params: {
+    message: ConversationMessageRecord;
+    messageSid: string;
+    providerStatus: string;
+    normalizedStatus: MessageDeliveryStatusType;
+    callbackReceivedAt: Date;
+    providerErrorCode?: string | null;
+    providerErrorMessage?: string | null;
+}) {
+    return {
+        tenantId: params.message.tenantId,
+        conversationId: params.message.conversationId,
+        messageId: params.message.id,
+        sid: params.messageSid,
+        providerStatus: params.providerStatus,
+        normalizedStatus: params.normalizedStatus,
+        timestamp: params.callbackReceivedAt.toISOString(),
+        providerErrorCode: params.providerErrorCode ?? null,
+        providerErrorMessage: params.providerErrorMessage ?? null,
+    } satisfies Record<string, unknown>;
+}
+
+export const whatsappDeliveryStatusService = {
+    async updateDeliveryStatus(params: UpdateDeliveryStatusParams): Promise<UpdateDeliveryStatusResult> {
+        const messageSid = normalizeOptionalString(params.messageSid);
+        const providerStatus = normalizeOptionalString(params.providerStatus) ?? params.providerStatus;
+        const callbackReceivedAt = params.callbackReceivedAt ?? new Date();
+        const providerErrorCode = normalizeOptionalString(params.providerErrorCode);
+        const providerErrorMessage = normalizeOptionalString(params.providerErrorMessage);
+        const normalizedStatus = normalizeTwilioDeliveryStatus(providerStatus);
+
+        if (!messageSid || !normalizedStatus) {
+            structuredLogger.warn('whatsapp_delivery_status_unknown', {
+                messageSid: messageSid ?? null,
+                providerStatus,
+                providerErrorCode,
+            });
+
+            return {
+                outcome: 'ignored_unknown_status',
+                providerStatus,
+            };
+        }
+
+        const existing = await conversationService.getMessageByProviderMessageId(messageSid);
+        if (!existing) {
+            structuredLogger.info('whatsapp_delivery_status_message_missing', {
+                messageSid,
+                providerStatus,
+                normalizedStatus,
+            });
+
+            return {
+                outcome: 'message_not_found',
+                normalizedStatus,
+                providerStatus,
+            };
+        }
+
+        if (existing.direction !== 'outbound') {
+            structuredLogger.warn('whatsapp_delivery_status_non_outbound', {
+                tenantId: existing.tenantId,
+                messageId: existing.id,
+                conversationId: existing.conversationId,
+                messageSid,
+                providerStatus,
+            });
+
+            return {
+                outcome: 'ignored_non_outbound',
+                tenantId: existing.tenantId,
+                conversationId: existing.conversationId,
+                messageId: existing.id,
+                normalizedStatus,
+                previousStatus: existing.deliveryStatus,
+                providerStatus,
+            };
+        }
+
+        const transition = classifyDeliveryStatusTransition(existing.deliveryStatus, normalizedStatus);
+        if (transition !== 'apply') {
+            structuredLogger.info('whatsapp_delivery_status_ignored', {
+                tenantId: existing.tenantId,
+                messageId: existing.id,
+                conversationId: existing.conversationId,
+                messageSid,
+                previousStatus: existing.deliveryStatus,
+                providerStatus,
+                normalizedStatus,
+                reason: transition,
+            });
+
+            return {
+                outcome: transition === 'duplicate' ? 'duplicate' : 'ignored_out_of_order',
+                tenantId: existing.tenantId,
+                conversationId: existing.conversationId,
+                messageId: existing.id,
+                normalizedStatus,
+                previousStatus: existing.deliveryStatus,
+                providerStatus,
+            };
+        }
+
+        const metadata = mergeMessageDeliveryTrackingMetadata(
+            (existing.metadata as Record<string, unknown> | null | undefined) ?? null,
+            {
+                sid: messageSid,
+                providerStatus,
+                normalizedStatus,
+                statusUpdatedAt: callbackReceivedAt,
+                providerErrorCode,
+                providerErrorMessage,
+            },
+        );
+
+        try {
+            const db = await getDb();
+            const failurePayload = buildFailureEventPayload({
+                message: existing,
+                messageSid,
+                providerStatus,
+                normalizedStatus,
+                callbackReceivedAt,
+                providerErrorCode,
+                providerErrorMessage,
+            });
+
+            await db.transaction(async (tx) => {
+                await tx.update(conversationMessages)
+                    .set({
+                        deliveryStatus: normalizedStatus,
+                        metadata,
+                    })
+                    .where(and(
+                        eq(conversationMessages.id, existing.id),
+                        eq(conversationMessages.tenantId, existing.tenantId),
+                    ));
+
+                if (normalizedStatus === 'failed' && existing.conversationId) {
+                    await tx.update(conversations)
+                        .set({ status: 'failed_delivery' })
+                        .where(and(
+                            eq(conversations.id, existing.conversationId),
+                            eq(conversations.tenantId, existing.tenantId),
+                        ));
+                }
+
+                await tx.insert(operationalEvents).values({
+                    id: randomUUID(),
+                    tenantId: existing.tenantId,
+                    eventType: 'delivery_status_changed',
+                    eventDomain: 'OPERATIONS',
+                    entityId: existing.id,
+                    payload: {
+                        conversationId: existing.conversationId,
+                        messageId: existing.id,
+                        sid: messageSid,
+                        previousStatus: existing.deliveryStatus ?? null,
+                        normalizedStatus,
+                        providerStatus,
+                        timestamp: callbackReceivedAt.toISOString(),
+                    },
+                });
+
+                if (normalizedStatus === 'failed') {
+                    await tx.insert(operationalEvents).values({
+                        id: randomUUID(),
+                        tenantId: existing.tenantId,
+                        eventType: 'MESSAGE_DELIVERY_FAILED',
+                        eventDomain: 'OPERATIONS',
+                        entityId: existing.conversationId ?? existing.id,
+                        payload: failurePayload,
+                    });
+                }
+            });
+
+            if (normalizedStatus === 'failed') {
+                void ecosystemEventsService.emitEvent({
+                    tenantId: existing.tenantId,
+                    type: 'message_delivery_failed',
+                    entityType: 'conversation_message',
+                    entityId: existing.id,
+                    payload: failurePayload,
+                    actor: 'system',
+                    source: 'whatsapp_status',
+                }).catch((error) => {
+                    logger.error('whatsapp_delivery_failure_ecosystem_event_failed', error as Error, {
+                        tenantId: existing.tenantId,
+                        messageId: existing.id,
+                        messageSid,
+                    });
+                });
+
+                structuredLogger.info('whatsapp_delivery_failure_event_published', {
+                    tenantId: existing.tenantId,
+                    conversationId: existing.conversationId,
+                    messageId: existing.id,
+                    messageSid,
+                    providerStatus,
+                    normalizedStatus,
+                    providerErrorCode,
+                });
+            }
+
+            structuredLogger.info('whatsapp_delivery_status_updated', {
+                tenantId: existing.tenantId,
+                conversationId: existing.conversationId,
+                messageId: existing.id,
+                messageSid,
+                previousStatus: existing.deliveryStatus,
+                providerStatus,
+                normalizedStatus,
+            });
+
+            return {
+                outcome: 'updated',
+                tenantId: existing.tenantId,
+                conversationId: existing.conversationId,
+                messageId: existing.id,
+                normalizedStatus,
+                previousStatus: existing.deliveryStatus,
+                providerStatus,
+            };
+        } catch (error) {
+            logger.error('whatsapp_delivery_status_persist_failed', error as Error, {
+                tenantId: existing.tenantId,
+                conversationId: existing.conversationId,
+                messageId: existing.id,
+                messageSid,
+                providerStatus,
+                normalizedStatus,
+            });
+            throw error;
+        }
+    },
+};

--- a/src/modules/atendimento/whatsapp-outbound.service.ts
+++ b/src/modules/atendimento/whatsapp-outbound.service.ts
@@ -1,0 +1,184 @@
+import type { ConversationMessageRecord, MessageDeliveryStatusType } from '@/drizzle/schema';
+import {
+    twilioProvider,
+    type TwilioSendFailure,
+    type TwilioSendSuccess,
+} from '@/providers/twilio.provider';
+import { conversationService } from './conversation.service';
+import {
+    mergeMessageDeliveryTrackingMetadata,
+    resolveInitialOutboundDeliveryStatus,
+} from './whatsapp-delivery-status.service';
+
+interface TrackedSendFailure extends Omit<TwilioSendFailure, 'errorCode'> {
+    errorCode:
+        | TwilioSendFailure['errorCode']
+        | 'MISSING_MESSAGE_SID';
+}
+
+export interface SendTrackedWhatsAppMessageParams {
+    tenantId: string;
+    conversationId: string;
+    to: string;
+    message: string;
+    source: 'OPERATOR' | 'SYSTEM';
+    actorType: 'HUMAN' | 'AI' | 'SYSTEM';
+    customerId?: string;
+    metadata?: Record<string, unknown>;
+}
+
+export type SendTrackedWhatsAppMessageResult =
+    | {
+        ok: true;
+        conversationMessage: ConversationMessageRecord;
+        updatedMessage: ConversationMessageRecord | undefined;
+        sendResult: TwilioSendSuccess;
+        normalizedStatus: MessageDeliveryStatusType;
+    }
+    | {
+        ok: false;
+        conversationMessage: ConversationMessageRecord;
+        sendResult: TrackedSendFailure;
+    };
+
+function normalizeOptionalString(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+}
+
+export const whatsappOutboundService = {
+    async sendTrackedMessage(params: SendTrackedWhatsAppMessageParams): Promise<SendTrackedWhatsAppMessageResult> {
+        const queuedMetadata = {
+            ...params.metadata,
+            channel: 'whatsapp',
+            actorType: params.actorType,
+            messageType: params.metadata?.messageType ?? 'TEXT',
+            status: params.metadata?.status ?? 'queued_for_send',
+            queuedAt: new Date().toISOString(),
+        };
+
+        const conversationMessage = await conversationService.processOutboundMessage(
+            params.tenantId,
+            params.conversationId,
+            params.message,
+            params.source,
+            params.customerId,
+            queuedMetadata,
+            { advanceConversation: false },
+        );
+
+        try {
+            const sendResult = await twilioProvider.sendMessageDetailed(params.tenantId, {
+                to: params.to,
+                body: params.message,
+            });
+
+            if (!sendResult.ok) {
+                const failedMetadata = {
+                    ...queuedMetadata,
+                    status: 'send_error',
+                    errorCode: sendResult.errorCode,
+                    errorMessage: sendResult.message,
+                    providerStatusCode: sendResult.providerStatusCode ?? null,
+                    failedAt: new Date().toISOString(),
+                    retryable: sendResult.retryable ?? false,
+                };
+
+                await conversationService.updateMessageFields(params.tenantId, conversationMessage.id, {
+                    metadata: failedMetadata,
+                    deliveryStatus: 'failed',
+                });
+
+                return {
+                    ok: false,
+                    conversationMessage,
+                    sendResult,
+                };
+            }
+
+            const sid = normalizeOptionalString(sendResult.sid);
+            if (!sid) {
+                const failedMetadata = {
+                    ...queuedMetadata,
+                    status: 'send_error',
+                    errorCode: 'MISSING_MESSAGE_SID',
+                    errorMessage: 'Twilio send succeeded without a MessageSid',
+                    providerStatusCode: sendResult.providerStatusCode ?? null,
+                    failedAt: new Date().toISOString(),
+                    retryable: false,
+                };
+
+                await conversationService.updateMessageFields(params.tenantId, conversationMessage.id, {
+                    metadata: failedMetadata,
+                    deliveryStatus: 'failed',
+                });
+
+                return {
+                    ok: false,
+                    conversationMessage,
+                    sendResult: {
+                        ok: false,
+                        errorCode: 'MISSING_MESSAGE_SID',
+                        message: 'Twilio send succeeded without a MessageSid',
+                        to: sendResult.to,
+                        attempts: sendResult.attempts,
+                        providerStatusCode: sendResult.providerStatusCode,
+                        retryable: false,
+                    },
+                };
+            }
+
+            const normalizedStatus = resolveInitialOutboundDeliveryStatus(sendResult.status);
+            const sentAt = new Date();
+            const sentMetadata = {
+                ...mergeMessageDeliveryTrackingMetadata(
+                    (conversationMessage.metadata as Record<string, unknown> | null | undefined) ?? queuedMetadata,
+                    {
+                        sid,
+                        providerStatus: sendResult.status,
+                        normalizedStatus,
+                        statusUpdatedAt: sentAt,
+                    },
+                ),
+                status: 'sent_ok',
+                providerStatusCode: sendResult.providerStatusCode,
+                attempts: sendResult.attempts,
+                sentAt: sentAt.toISOString(),
+            };
+
+            const updatedMessage = await conversationService.updateMessageFields(params.tenantId, conversationMessage.id, {
+                metadata: sentMetadata,
+                providerMessageId: sid,
+                deliveryStatus: normalizedStatus,
+            });
+
+            return {
+                ok: true,
+                conversationMessage,
+                updatedMessage,
+                sendResult: {
+                    ...sendResult,
+                    sid,
+                },
+                normalizedStatus,
+            };
+        } catch (error) {
+            const failedMetadata = {
+                ...queuedMetadata,
+                status: 'send_error',
+                errorCode: 'UNKNOWN_ERROR',
+                errorMessage: error instanceof Error ? error.message : String(error),
+                failedAt: new Date().toISOString(),
+                retryable: false,
+            };
+
+            await conversationService.updateMessageFields(params.tenantId, conversationMessage.id, {
+                metadata: failedMetadata,
+                deliveryStatus: 'failed',
+            }).catch(() => undefined);
+
+            throw error;
+        }
+    },
+};

--- a/src/services/ecosystem-events.service.ts
+++ b/src/services/ecosystem-events.service.ts
@@ -14,6 +14,7 @@ export const EcosystemEventTypes = [
     'shipment_created',
     'shipment_delayed',
     'message_received',
+    'message_delivery_failed',
     'quote_generated',
     'note_added',
     'followup_scheduled',


### PR DESCRIPTION
## Contexto
A auditoria apontou que o delivery status do WhatsApp nunca saía de `queued` com confiabilidade: o callback `/api/whatsapp/status` existia, mas a persistência de `delivered/failed` era parcial, `failed/undelivered` não geravam evento operacional e parte do outbound core nem persistia `providerMessageId`, o que quebrava o tracking no retorno do Twilio.

## Problema
- A rota de status tinha lógica acoplada, sem camada de domínio para idempotência e callbacks fora de ordem.
- `accepted/sending` podiam tentar gravar status cru do Twilio fora do vocabulário interno.
- O envio de quote não persistia `sid`, então o callback nunca encontrava a mensagem.
- Falhas de entrega não publicavam um evento operacional dedicado para consumo/auditoria.
- Logs do webhook expunham payload cru desnecessariamente.

## Decisão técnica
- Extraí a regra de domínio para `src/modules/atendimento/whatsapp-delivery-status.service.ts`, com:
  - normalização segura dos status do Twilio para o vocabulário interno (`queued/sent/delivered/read/failed`)
  - transições forward-only e idempotência para callbacks duplicados ou fora de ordem
  - persistência do status e metadata de tracking por `providerMessageId`
  - publicação de `delivery_status_changed` e `MESSAGE_DELIVERY_FAILED` no barramento operacional
  - emissão adicional de `message_delivery_failed` no ecosystem event bus para consumidores in-process
- Extraí o envio outbound core para `src/modules/atendimento/whatsapp-outbound.service.ts`, garantindo persistência inicial da mensagem, atualização do `sid` e normalização do status inicial do Twilio.
- Reescrevi `/api/whatsapp/status` para ficar fina: validar assinatura, rate limit, parsing e delegação ao serviço.
- Refatorei os fluxos core de envio em:
  - `src/app/api/cockpit/conversations/[id]/message/route.ts`
  - `src/app/api/cockpit/conversations/[id]/quotes/[quoteId]/send/route.ts`
  para usar o helper outbound e não perder `sid`.
- Mantive o schema atual sem migration: `failed/undelivered` continuam normalizados para `failed`, então não há drift nem expansão de enum.

## Impacto
- Mensagens outbound core passam a persistir `sid` e status inicial normalizado imediatamente após o envio.
- O callback do Twilio agora atualiza `deliveryStatus` no banco com tratamento explícito para `queued`, `accepted`, `sending`, `sent`, `delivered`, `read`, `failed` e `undelivered`.
- `failed` e `undelivered` publicam `MESSAGE_DELIVERY_FAILED` com payload operacional útil (`tenantId`, `conversationId`, `messageId`, `sid`, `providerStatus`, `normalizedStatus`, `timestamp`, `providerErrorCode`, `providerErrorMessage`).
- Callbacks duplicados ou regressivos deixam de corromper estado.
- Observabilidade melhora com logs estruturados sem payload bruto/PII.

## Testes executados
- `npm run test:win-stable -- src/modules/atendimento/__tests__/whatsapp-delivery-status.service.test.ts src/modules/atendimento/__tests__/whatsapp-outbound.service.test.ts src/app/api/whatsapp/status/__tests__/route.test.ts`
- `npm run typecheck`
- `npm run guardrail:mvp-freeze`
- `npm run scope:pr-tests`
- `$env:PII_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'; npm run test:whatsapp`
- `npm run test:freight`
- `npm run routes:verify-security`
- `npm run routes:sync`
- `npm run lint`
- `npm run db:verify`
- `npm run build`

## Schema / migrations
- Nenhuma migration.
- `db:verify` confirmou ausência de drift.
