### PR TITLE
fix(cockpit): pedidosHoje e erros24h com queries reais

### DIFF
--- a/src/app/api/cockpit/metrics/__tests__/route.test.ts
+++ b/src/app/api/cockpit/metrics/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../route';
+import { requireAdmin } from '@/infra/auth/guards';
+import { messageRepository } from '@/infra/repositories/message.repository';
+import { simulationRepository } from '@/infra/repositories/simulation.repository';
+import { redisClient } from '@/infra/redis.client';
+import { getDb } from '@/infra/db';
+
+vi.mock('@/infra/auth/guards', () => ({
+    requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/infra/repositories/message.repository', () => ({
+    messageRepository: {
+        getMetricsToday: vi.fn(),
+    },
+}));
+
+vi.mock('@/infra/repositories/simulation.repository', () => ({
+    simulationRepository: {
+        countToday: vi.fn(),
+    },
+}));
+
+vi.mock('@/infra/redis.client', () => ({
+    redisClient: {
+        isAvailable: vi.fn(),
+        get: vi.fn(),
+        set: vi.fn(),
+    },
+}));
+
+vi.mock('@/infra/db', () => ({
+    getDb: vi.fn(),
+}));
+
+describe('GET /api/cockpit/metrics', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        vi.mocked(requireAdmin).mockResolvedValue({
+            ok: true,
+            session: { tenantId: 'tenant-1' } as any,
+        } as any);
+
+        vi.mocked(redisClient.isAvailable).mockReturnValue(false);
+        vi.mocked(redisClient.get).mockResolvedValue(null);
+        vi.mocked(redisClient.set).mockResolvedValue(undefined as never);
+
+        vi.mocked(messageRepository.getMetricsToday).mockResolvedValue({ total: 10 } as any);
+        vi.mocked(simulationRepository.countToday).mockResolvedValue(5);
+
+        const mockDb = {
+            select: vi.fn().mockReturnThis(),
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockResolvedValue([{ count: 42 }]),
+        };
+        vi.mocked(getDb).mockResolvedValue(mockDb as any);
+    });
+
+    it('returns tenant-scoped metrics including DB queries for orders and errors', async () => {
+        const request = {
+            nextUrl: new URL('http://localhost/api/cockpit/metrics'),
+            headers: new Headers(),
+        } as never;
+
+        const response = await GET(request);
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json).toEqual(expect.objectContaining({
+            mensagensHoje: 10,
+            cotacoesHoje: 5,
+            pedidosHoje: 42,
+            erros24h: 42,
+        }));
+    });
+});

--- a/src/app/api/cockpit/metrics/route.ts
+++ b/src/app/api/cockpit/metrics/route.ts
@@ -17,7 +17,8 @@ import { redisClient } from "@/infra/redis.client";
 import { logger } from '@/infra/logger';
 import { requireAdmin } from '@/infra/auth/guards';
 import { getDb } from '@/infra/db';
-import { sql } from 'drizzle-orm';
+import { sql, eq, and, gte, or, like } from 'drizzle-orm';
+import { orders, operationalEvents } from '@/drizzle/schema';
 import { buildAttributionBreakdown, isAttributionGroupBy, parseAttributionGroupBy, unwrapRows } from '@/modules/metrics/attribution-breakdown';
 import { attachRequestIdHeader, makeRequestId } from '@/infra/http/request-trace';
 import { ErrorCode, errorResponse, inferErrorCodeFromStatus } from '@/infra/http/error-response';
@@ -34,7 +35,7 @@ interface CockpitMetrics {
   };
 }
 
-const CACHE_TTL_SECONDS = 30;
+const CACHE_TTL_SECONDS = 60;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
@@ -93,7 +94,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     // Real DB queries in parallel (tenant-isolated)
-    const [msgMetrics, cotacoesHoje, attributionBreakdownResult] = await Promise.all([
+    const [msgMetrics, cotacoesHoje, attributionBreakdownResult, pedidosResult, errosResult] = await Promise.all([
       messageRepository.getMetricsToday(tenantId),
       simulationRepository.countToday(tenantId),
       groupBy
@@ -120,13 +121,45 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             );
           })()
         : Promise.resolve(null),
+      // pedidosHoje: orders created today for this tenant
+      (async () => {
+        const db = await getDb();
+        const rows = await db
+          .select({ count: sql<number>`COUNT(*)` })
+          .from(orders)
+          .where(
+            and(
+              eq(orders.tenantId, tenantId),
+              gte(orders.createdAt, sql`CURDATE()`)
+            )
+          );
+        return rows[0]?.count ?? 0;
+      })(),
+      // erros24h: operational_events with error/failed event types in last 24h
+      (async () => {
+        const db = await getDb();
+        const rows = await db
+          .select({ count: sql<number>`COUNT(*)` })
+          .from(operationalEvents)
+          .where(
+            and(
+              eq(operationalEvents.tenantId, tenantId),
+              gte(operationalEvents.createdAt, sql`NOW() - INTERVAL 24 HOUR`),
+              or(
+                like(operationalEvents.eventType, '%FAILED%'),
+                like(operationalEvents.eventType, '%ERROR%')
+              )
+            )
+          );
+        return rows[0]?.count ?? 0;
+      })(),
     ]);
 
     const payload: CockpitMetrics = {
       mensagensHoje: Number(msgMetrics.total ?? 0),
       cotacoesHoje: Number(cotacoesHoje ?? 0),
-      pedidosHoje: 0, // TODO: orders table
-      erros24h: 0,    // TODO: error_log table
+      pedidosHoje: Number(pedidosResult),
+      erros24h: Number(errosResult),
     };
 
     if (groupBy && attributionBreakdownResult) {
@@ -151,7 +184,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     return finalize(NextResponse.json(payload, {
       status: 200,
-      headers: { 'Cache-Control': groupBy ? 'no-store, max-age=0' : 'private, max-age=30', 'X-Request-Id': requestId },
+      headers: { 'Cache-Control': groupBy ? 'no-store, max-age=0' : 'private, max-age=60', 'X-Request-Id': requestId },
     }));
   } catch (error) {
     structuredLogger.error('cockpit_metrics_failed', {


### PR DESCRIPTION
## Problema

GET /api/cockpit/metrics retornava pedidosHoje: 0 e erros24h: 0 hardcoded, tornando o dashboard cockpit inútil.

## Solução

### pedidosHoje
Query real em orders:
\\\sql
SELECT COUNT(*) FROM orders
WHERE tenant_id = :tenantId AND created_at >= CURDATE()
\\\

### erros24h
Query real em operational_events:
\\\sql
SELECT COUNT(*) FROM operational_events
WHERE tenant_id = :tenantId
  AND created_at >= NOW() - INTERVAL 24 HOUR
  AND (event_type LIKE '%FAILED%' OR event_type LIKE '%ERROR%')
\\\

### Schema validado
- Tabelas: orders, operational_events (ambas existem em src/drizzle/schema.ts)
- Colunas usadas: 	enant_id, created_at, event_type — nomes confirmados no schema real
- Isolamento por tenant: eq(table.tenantId, tenantId) em todas as queries

### Cache Redis
- TTL atualizado de 30s para 60s conforme auditoria
- Chave: cockpit:metrics:{tenantId} (tenant-isolada, sem mudança)

## Arquivos alterados
- src/app/api/cockpit/metrics/route.ts — queries reais + TTL 60s
- src/app/api/cockpit/metrics/__tests__/route.test.ts — novo, testa comportamento

## Validações
- [x] 
pm run typecheck — ✅ zero erros
- [x] 
pm run lint — ✅ zero erros  
- [x] 
pm run test:cockpit — ✅ 19 test files, 52 tests passed (incluindo novo route.test.ts)
- [x] Sem mudanças de contrato público
- [x] Scope mínimo: apenas metrics/route.ts + teste

## Escopo MVP
MVP Core — cockpit diário de operação ✅