### PR TITLE
feat(tudico): add statistical validation tool (p-value + CI)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@ Isolamento por tenant é implementado em múltiplas barreiras:
 | Cockpit | `src/modules/cockpit/**` | Dados agregados para painéis, alertas, filas, métricas e atalhos |
 | Frank | `src/modules/frank/**`, `src/core/ai/**` | Intent/context resolver, sugestões, tools, memória, gateway LLM e governança |
 | DOMINE | `src/modules/domine/**`, `src/domine/**` | Publicação/processamento de eventos com status, retries e DLQ |
-| Tudico (research SDD) | `src/modules/cockpit/tudico/**`, `src/app/api/cockpit/tudico/**`, `src/app/(app)/cockpit/tudico/**` | Curadoria epistemológica com hipótese versionada, paper cards, inconsistências e auditoria de resposta |
+| Tudico (research SDD) | `src/modules/cockpit/tudico/**`, `src/app/api/cockpit/tudico/**`, `src/app/(app)/cockpit/tudico/**` | Curadoria epistemológica com hipótese versionada, paper cards, inconsistências, auditoria de resposta e validação estatística (p-value/confiança) |
 | Billing/FinOps | `src/modules/billing/**`, `src/modules/finops/**` | Plano, Stripe webhook/service e enforcement operacional por plano |
 
 ## 6) Integrações externas reais

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Para demos/pilotos reproduzíveis, use o runbook em [`docs/demo/demo-tenant-runb
 - **Frank agent loop (base mínima)**: camada incremental com planner/policy/tool contract (`ToolResult`), memória operacional básica e telemetria estruturada no fluxo de conversão de cotação aprovada para pedido.
 - **Frank sub-agent separation (MVP)**: planner com responsabilidade explícita por sub-agente (`ATENDIMENTO`, `CRM`, `FREIGHT`, `LOGISTICA`) e handoff rastreável em auditoria/log para reduzir acoplamento entre domínios.
 - **Eventos operacionais e DOMINE**: publicação de eventos com sanitização de PII, processamento assíncrono com DLQ e trilha de auditoria.
-- **Tudico Fase 2 (pesquisa epistemológica)**: versionamento de hipóteses, diff entre versões, paper cards, inconsistency board e auditoria epistemológica via tools dedicadas no cockpit.
+- **Tudico Fase 2 (pesquisa epistemológica)**: versionamento de hipóteses, diff entre versões, paper cards, inconsistency board, auditoria epistemológica e validação estatística (p-value + intervalo de confiança) via tools dedicadas no cockpit.
 
 ## Stack real
 

--- a/docs/mvp/tudico-fase-2-design.md
+++ b/docs/mvp/tudico-fase-2-design.md
@@ -29,6 +29,7 @@
 - `list_paper_cards`
 - `get_paper_card`
 - `list_claim_conflicts`
+- `validate_statistical_signal` (MPV-56: validação estatística com p-value e intervalo de confiança)
 
 Todas expostas via `POST /api/cockpit/tudico/tools`.
 

--- a/src/app/api/cockpit/tudico/tools/route.ts
+++ b/src/app/api/cockpit/tudico/tools/route.ts
@@ -14,6 +14,7 @@ const toolSchema = z.object({
     'list_paper_cards',
     'get_paper_card',
     'list_claim_conflicts',
+    'validate_statistical_signal',
   ]),
   input: z.record(z.string(), z.unknown()).default({}),
 });

--- a/src/modules/cockpit/tudico/__tests__/tudico-runtime.service.test.ts
+++ b/src/modules/cockpit/tudico/__tests__/tudico-runtime.service.test.ts
@@ -14,3 +14,37 @@ describe('tudicoRuntimeService.auditResponse', () => {
     expect(result.score).toBeLessThan(100);
   });
 });
+
+describe('tudicoRuntimeService.validateStatisticalSignal', () => {
+  it('returns significant result when treatment outperforms control', async () => {
+    const result = await tudicoRuntimeService.validateStatisticalSignal({
+      controlSuccesses: 120,
+      controlTotal: 500,
+      treatmentSuccesses: 170,
+      treatmentTotal: 500,
+      confidenceLevel: 0.95,
+      alternative: 'two-sided',
+    });
+
+    expect(result.treatmentRate).toBeGreaterThan(result.controlRate);
+    expect(result.pValue).toBeLessThan(0.05);
+    expect(result.isSignificant).toBe(true);
+    expect(result.confidenceInterval.lower).toBeGreaterThan(0);
+  });
+
+  it('returns non-significant result when samples are close', async () => {
+    const result = await tudicoRuntimeService.validateStatisticalSignal({
+      controlSuccesses: 240,
+      controlTotal: 1000,
+      treatmentSuccesses: 250,
+      treatmentTotal: 1000,
+      confidenceLevel: 0.95,
+      alternative: 'two-sided',
+    });
+
+    expect(result.pValue).toBeGreaterThan(0.05);
+    expect(result.isSignificant).toBe(false);
+    expect(result.confidenceInterval.lower).toBeLessThan(0);
+    expect(result.confidenceInterval.upper).toBeGreaterThan(0);
+  });
+});

--- a/src/modules/cockpit/tudico/tudico-runtime.service.ts
+++ b/src/modules/cockpit/tudico/tudico-runtime.service.ts
@@ -8,10 +8,12 @@ import {
   inconsistencyItemSchema,
   logInconsistencySchema,
   paperCardSchema,
+  statisticalValidationInputSchema,
   type EpistemicAuditResult,
   type HypothesisVersion,
   type InconsistencyItem,
   type PaperCard,
+  type StatisticalValidationResult,
 } from './tudico.types';
 
 function tokenize(text: string): string[] {
@@ -88,6 +90,95 @@ function runEpistemicAudit(responseText: string, claimIds: string[]): EpistemicA
 
   const score = Math.max(0, 100 - alerts.length * 20);
   return { claimIds, alerts, score };
+}
+
+function normalCdf(value: number): number {
+  const sign = value < 0 ? -1 : 1;
+  const x = Math.abs(value) / Math.SQRT2;
+  const t = 1 / (1 + 0.3275911 * x);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const y = 1 - (((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x));
+  const erf = sign * y;
+  return (1 + erf) / 2;
+}
+
+function inverseNormalCdf(probability: number): number {
+  // Peter John Acklam approximation.
+  const a = [-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02, 1.38357751867269e+02, -3.066479806614716e+01, 2.506628277459239e+00];
+  const b = [-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02, 6.680131188771972e+01, -1.328068155288572e+01];
+  const c = [-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00, -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00];
+  const d = [7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00, 3.754408661907416e+00];
+
+  const pLow = 0.02425;
+  const pHigh = 1 - pLow;
+  if (probability <= 0 || probability >= 1) throw new Error('Probability must be between 0 and 1');
+
+  if (probability < pLow) {
+    const q = Math.sqrt(-2 * Math.log(probability));
+    return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+  }
+  if (probability > pHigh) {
+    const q = Math.sqrt(-2 * Math.log(1 - probability));
+    return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+  }
+
+  const q = probability - 0.5;
+  const r = q * q;
+  return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1);
+}
+
+function runStatisticalValidation(payload: unknown): StatisticalValidationResult {
+  const parsed = statisticalValidationInputSchema.parse(payload);
+  const {
+    controlSuccesses,
+    controlTotal,
+    treatmentSuccesses,
+    treatmentTotal,
+    confidenceLevel,
+    alternative,
+  } = parsed;
+
+  if (controlSuccesses > controlTotal) throw new Error('controlSuccesses cannot be greater than controlTotal');
+  if (treatmentSuccesses > treatmentTotal) throw new Error('treatmentSuccesses cannot be greater than treatmentTotal');
+
+  const controlRate = controlSuccesses / controlTotal;
+  const treatmentRate = treatmentSuccesses / treatmentTotal;
+  const absoluteDelta = treatmentRate - controlRate;
+  const relativeLift = controlRate === 0 ? null : absoluteDelta / controlRate;
+
+  const pooled = (controlSuccesses + treatmentSuccesses) / (controlTotal + treatmentTotal);
+  const pooledVariance = pooled * (1 - pooled) * (1 / controlTotal + 1 / treatmentTotal);
+  const zScore = pooledVariance === 0 ? 0 : absoluteDelta / Math.sqrt(pooledVariance);
+
+  let pValue = 1;
+  if (alternative === 'two-sided') pValue = 2 * (1 - normalCdf(Math.abs(zScore)));
+  if (alternative === 'greater') pValue = 1 - normalCdf(zScore);
+  if (alternative === 'less') pValue = normalCdf(zScore);
+
+  const alpha = 1 - confidenceLevel;
+  const zCritical = inverseNormalCdf(1 - alpha / 2);
+  const unpooledVariance = (controlRate * (1 - controlRate)) / controlTotal + (treatmentRate * (1 - treatmentRate)) / treatmentTotal;
+  const margin = zCritical * Math.sqrt(unpooledVariance);
+  const confidenceInterval = {
+    lower: absoluteDelta - margin,
+    upper: absoluteDelta + margin,
+  };
+
+  return {
+    controlRate,
+    treatmentRate,
+    absoluteDelta,
+    relativeLift,
+    zScore,
+    pValue,
+    confidenceLevel,
+    confidenceInterval,
+    isSignificant: pValue < alpha,
+  };
 }
 
 export class TudicoRuntimeService {
@@ -208,10 +299,21 @@ export class TudicoRuntimeService {
     return runEpistemicAudit(parsed.responseText, parsed.claimIds);
   }
 
+  async validateStatisticalSignal(payload: unknown): Promise<StatisticalValidationResult> {
+    return runStatisticalValidation(payload);
+  }
+
   async executeTool(
     tenantId: string,
     actorId: string,
-    tool: 'audit_response' | 'log_inconsistency' | 'compare_hypothesis_versions' | 'list_paper_cards' | 'get_paper_card' | 'list_claim_conflicts',
+    tool:
+      | 'audit_response'
+      | 'log_inconsistency'
+      | 'compare_hypothesis_versions'
+      | 'list_paper_cards'
+      | 'get_paper_card'
+      | 'list_claim_conflicts'
+      | 'validate_statistical_signal',
     input: Record<string, unknown>,
   ): Promise<unknown> {
     switch (tool) {
@@ -227,6 +329,8 @@ export class TudicoRuntimeService {
         return this.getPaperCard(tenantId, actorId, String(input.paperId));
       case 'list_claim_conflicts':
         return this.listClaimConflicts(tenantId, input.claimId ? String(input.claimId) : undefined);
+      case 'validate_statistical_signal':
+        return this.validateStatisticalSignal(input);
       default:
         throw new Error(`Unsupported tool: ${tool}`);
     }

--- a/src/modules/cockpit/tudico/tudico.types.ts
+++ b/src/modules/cockpit/tudico/tudico.types.ts
@@ -92,3 +92,27 @@ export type EpistemicAuditResult = {
   }>;
   score: number;
 };
+
+export const statisticalValidationInputSchema = z.object({
+  controlSuccesses: z.number().int().nonnegative(),
+  controlTotal: z.number().int().positive(),
+  treatmentSuccesses: z.number().int().nonnegative(),
+  treatmentTotal: z.number().int().positive(),
+  confidenceLevel: z.number().min(0.8).max(0.999).default(0.95),
+  alternative: z.enum(['two-sided', 'greater', 'less']).default('two-sided'),
+});
+
+export type StatisticalValidationResult = {
+  controlRate: number;
+  treatmentRate: number;
+  absoluteDelta: number;
+  relativeLift: number | null;
+  zScore: number;
+  pValue: number;
+  confidenceLevel: number;
+  confidenceInterval: {
+    lower: number;
+    upper: number;
+  };
+  isSignificant: boolean;
+};


### PR DESCRIPTION
### Motivation
- Provide a reproducible, auditable statistical check for Tudico research workflows to surface significance (p-value) and uncertainty (confidence interval) when comparing two proportions (control vs treatment) as requested in MPV-56.
- Make statistical validation available as a guarded backend tool so hypothesis authors can programmatically validate experimental signals alongside existing epistemic audits.

### Description
- Added typed input and output contracts `statisticalValidationInputSchema` and `StatisticalValidationResult` in `src/modules/cockpit/tudico/tudico.types.ts`.
- Implemented a two-proportion z-test flow with normal CDF and inverse CDF approximations and CI computation in `src/modules/cockpit/tudico/tudico-runtime.service.ts` and exposed it via `TudicoRuntimeService.validateStatisticalSignal`.
- Exposed the new tool in the Tudico tools dispatcher by adding `'validate_statistical_signal'` to the enum in `POST /api/cockpit/tudico/tools` (`src/app/api/cockpit/tudico/tools/route.ts`).
- Added unit tests for a significant and a non-significant scenario in `src/modules/cockpit/tudico/__tests__/tudico-runtime.service.test.ts` and updated docs (`README.md`, `ARCHITECTURE.md`, `docs/mvp/tudico-fase-2-design.md`) to record the capability.

### Testing
- Ran the guardrail check with `MVP_FREEZE_BASE=HEAD npm run guardrail:mvp-freeze` which passed for the changed files in this environment (note: running `npm run guardrail:mvp-freeze` without `MVP_FREEZE_BASE=HEAD` failed here because `origin/main` is not available locally).
- Executed the PR scope helper `npm run scope:pr-tests -- --files ...` which reported the expected cockpit test set and suggested gates.
- Ran the cockpit test suite with `npm run test:cockpit`, and the relevant Tudico tests passed as part of the suite (`tudico-runtime.service` tests included) with the test run completing successfully.
- Ran `npm run lint` and `npm run typecheck` which both completed without errors, and ran `npm run routes:verify-security` and `npm run routes:sync` which reported no route/security regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9af101e388331bc9d047bfe16cacd)