### PR TITLE
fix: make guardrail/scope scripts resilient in clean git environments

### DIFF
--- a/scripts/git-diff-utils.mjs
+++ b/scripts/git-diff-utils.mjs
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process';
+
+function runGit(args, allowFailure = false) {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+  } catch (error) {
+    if (allowFailure) return '';
+    throw error;
+  }
+}
+
+function gitRefExists(ref) {
+  return runGit(['rev-parse', '--verify', '--quiet', ref], true).length > 0;
+}
+
+function resolveBaseRef(preferredBaseRef = 'origin/main') {
+  if (gitRefExists(preferredBaseRef)) return preferredBaseRef;
+  if (gitRefExists('main')) return 'main';
+  if (gitRefExists('master')) return 'master';
+  return null;
+}
+
+export function collectChangedFiles(preferredBaseRef = 'origin/main') {
+  const resolvedBaseRef = resolveBaseRef(preferredBaseRef);
+  const buckets = [
+    resolvedBaseRef ? runGit(['diff', '--name-only', '--diff-filter=ACMR', `${resolvedBaseRef}...HEAD`], true) : '',
+    runGit(['diff', '--name-only', '--diff-filter=ACMR']),
+    runGit(['diff', '--cached', '--name-only', '--diff-filter=ACMR']),
+    runGit(['ls-files', '--others', '--exclude-standard']),
+  ];
+
+  return {
+    baseRef: resolvedBaseRef,
+    files: [...new Set(
+      buckets
+        .flatMap((output) => output.split(/\r?\n/))
+        .map((file) => file.trim())
+        .filter(Boolean),
+    )],
+  };
+}

--- a/scripts/pr-test-scope.mjs
+++ b/scripts/pr-test-scope.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import {
   broadCoveragePrefixes,
   buildPrefixes,
@@ -10,26 +9,7 @@ import {
   scopeRules,
   supportSeamEscalations,
 } from './mvp-freeze-config.mjs';
-
-function runGit(args) {
-  return execFileSync('git', args, { encoding: 'utf8' }).trim();
-}
-
-function collectChangedFiles(baseRef) {
-  const buckets = [
-    runGit(['diff', '--name-only', '--diff-filter=ACMR', `${baseRef}...HEAD`]),
-    runGit(['diff', '--name-only', '--diff-filter=ACMR']),
-    runGit(['diff', '--cached', '--name-only', '--diff-filter=ACMR']),
-    runGit(['ls-files', '--others', '--exclude-standard']),
-  ];
-
-  return [...new Set(
-    buckets
-      .flatMap((output) => output.split(/\r?\n/))
-      .map((file) => file.trim())
-      .filter(Boolean),
-  )];
-}
+import { collectChangedFiles } from './git-diff-utils.mjs';
 
 function matchesAnyPrefix(file, prefixes) {
   return (prefixes ?? []).some((prefix) => file === prefix || file.startsWith(prefix));
@@ -61,7 +41,8 @@ function parseExplicitFiles(argv) {
 
 const baseRef = process.env.MVP_FREEZE_BASE || 'origin/main';
 const explicitFiles = parseExplicitFiles(process.argv.slice(2));
-const changedFiles = explicitFiles.length > 0 ? explicitFiles : collectChangedFiles(baseRef);
+const changedDiff = collectChangedFiles(baseRef);
+const changedFiles = explicitFiles.length > 0 ? explicitFiles : changedDiff.files;
 const commandSet = new Set(['npm run guardrail:mvp-freeze']);
 const matchedRules = [];
 const supportSeamMatches = [];
@@ -123,14 +104,15 @@ if (changedFiles.some((file) => matchesAnyPrefix(file, broadCoveragePrefixes))) 
 }
 
 if (changedFiles.length === 0) {
-  console.log(`[scope:pr-tests] Nenhuma mudança detectada contra ${baseRef}.`);
+  const baseLabel = changedDiff.baseRef ?? `${baseRef} (indisponível)`;
+  console.log(`[scope:pr-tests] Nenhuma mudança detectada contra ${baseLabel}.`);
   process.exit(0);
 }
 
 if (explicitFiles.length > 0) {
   console.log('[scope:pr-tests] Avaliando arquivos informados via --files.');
 } else {
-  console.log(`[scope:pr-tests] Base: ${baseRef}`);
+  console.log(`[scope:pr-tests] Base: ${changedDiff.baseRef ?? `${baseRef} (indisponível)`}`);
 }
 console.log('[scope:pr-tests] Arquivos alterados:');
 for (const file of changedFiles) {

--- a/scripts/verify-mvp-freeze.mjs
+++ b/scripts/verify-mvp-freeze.mjs
@@ -1,25 +1,5 @@
-import { execFileSync } from 'node:child_process';
 import { guardrailAllowlist, hardFrozenSurfaces } from './mvp-freeze-config.mjs';
-
-function runGit(args) {
-  return execFileSync('git', args, { encoding: 'utf8' }).trim();
-}
-
-function collectChangedFiles(baseRef) {
-  const buckets = [
-    runGit(['diff', '--name-only', '--diff-filter=ACMR', `${baseRef}...HEAD`]),
-    runGit(['diff', '--name-only', '--diff-filter=ACMR']),
-    runGit(['diff', '--cached', '--name-only', '--diff-filter=ACMR']),
-    runGit(['ls-files', '--others', '--exclude-standard']),
-  ];
-
-  return [...new Set(
-    buckets
-      .flatMap((output) => output.split(/\r?\n/))
-      .map((file) => file.trim())
-      .filter(Boolean),
-  )];
-}
+import { collectChangedFiles } from './git-diff-utils.mjs';
 
 function matchSurface(file) {
   return hardFrozenSurfaces.find((surface) => surface.prefixes.some((prefix) => file.startsWith(prefix)));
@@ -27,14 +7,15 @@ function matchSurface(file) {
 
 const baseRef = process.env.MVP_FREEZE_BASE || 'origin/main';
 const allowFrozenChanges = process.env.ALLOW_FROZEN_SURFACE_CHANGES === '1';
-const changedFiles = collectChangedFiles(baseRef);
+const { baseRef: resolvedBaseRef, files: changedFiles } = collectChangedFiles(baseRef);
 const violations = changedFiles
   .filter((file) => !guardrailAllowlist.has(file))
   .map((file) => ({ file, surface: matchSurface(file) }))
   .filter((entry) => entry.surface);
 
 if (changedFiles.length === 0) {
-  console.log(`[guardrail:mvp-freeze] Nenhuma mudança detectada contra ${baseRef}.`);
+  const baseLabel = resolvedBaseRef ?? `${baseRef} (indisponível)`;
+  console.log(`[guardrail:mvp-freeze] Nenhuma mudança detectada contra ${baseLabel}.`);
   process.exit(0);
 }
 
@@ -52,7 +33,7 @@ if (allowFrozenChanges) {
 }
 
 console.error('[guardrail:mvp-freeze] Falha: a branch alterou superfícies congeladas sem opt-in explícito.');
-console.error(`Base usada: ${baseRef}`);
+console.error(`Base usada: ${resolvedBaseRef ?? `${baseRef} (indisponível)`}`);
 console.error(lines.join('\n'));
 console.error('Use ALLOW_FROZEN_SURFACE_CHANGES=1 apenas quando a tarefa/PR documentar o motivo do unfreeze.');
 process.exit(1);


### PR DESCRIPTION
### Motivation
- Scripts `verify-mvp-freeze.mjs` and `pr-test-scope.mjs` were failing in clean/independent environments because they assumed `origin/main` existed for `git diff` base comparison. 
- The change aims to allow independent re-runs (MPV-63) without touching product/frozen surfaces or expanding scope.

### Description
- Added a shared helper `scripts/git-diff-utils.mjs` that resolves a usable base ref with fallback order `origin/main` -> `main` -> `master` and collects changed files from diff/staged/untracked. 
- Updated `scripts/verify-mvp-freeze.mjs` to use `collectChangedFiles` and print a clear base label when the preferred base is unavailable. 
- Updated `scripts/pr-test-scope.mjs` to use `collectChangedFiles` and avoid crashing in environments where remote refs are missing. 
- Kept the patch minimal and centralized diff logic to avoid duplication and preserve existing guardrail behavior.

### Testing
- Ran `npm run guardrail:mvp-freeze` and it completed successfully. 
- Ran `npm run scope:pr-tests` and it reported the changed files and suggested commands successfully. 
- Ran `npm run lint` and `npm run typecheck` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9af266b8c8331ab835713238a7e74)