### PR TITLE
chore: add first tenant readiness validation

### DIFF
--- a/docs/runbooks/first-tenant-readiness.md
+++ b/docs/runbooks/first-tenant-readiness.md
@@ -1,0 +1,53 @@
+# Runbook: Onboarding Técnico do Primeiro Tenant Real
+
+## Objetivo
+Este documento descreve o processo de provisionamento, ativação e validação do primeiro tenant real no CONDSTORE OS.
+
+## Pré-requisitos
+- Acesso ao TiDB Cloud (Produção).
+- Acesso à Vercel (Deploy).
+- Vercel CLI instalada e linkada ao projeto.
+- Variáveis de ambiente configuradas no `.env.local` (via `vercel env pull`).
+
+## Variáveis de Ambiente Necessárias (Nomes)
+- `DATABASE_URL`
+- `AUTH_SECRET`
+- `PII_ENCRYPTION_KEY`
+- `REDIS_URL`
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- `MELHOR_ENVIO_TOKEN`
+- `STRIPE_SECRET_KEY`
+
+## Passo 1: Seed de Provisionamento
+Para provisionar o tenant inicial com dados de demonstração ou estrutura básica:
+```bash
+npm run seed:demo-tenant
+```
+
+## Passo 2: Validação de Readiness
+Após o seed, execute a validação automatizada para garantir que o tenant, o usuário admin e o plano estão corretos:
+```bash
+npm run tenant:readiness
+```
+
+## Checklist Operacional do Primeiro Tenant
+- [ ] Tenant criado com slug correto.
+- [ ] Usuário admin cadastrado com role `admin`.
+- [ ] Plano definido como `active` ou `trialing`.
+- [ ] Login testado no Dashboard (`https://app.condstoreos.com`).
+- [ ] Acesso ao Cockpit verificado.
+- [ ] Configurações de canal (WhatsApp) mapeadas.
+
+## Próximos Passos (Manuais)
+O responsável (Rafa) deve realizar as integrações externas reais via Dashboard ou Variáveis de Ambiente:
+1. **Twilio**: Configurar Webhook da Sandbox ou Número Real para `https://app.condstoreos.com/api/whatsapp/incoming`.
+2. **Melhor Envio**: Inserir Token de produção.
+3. **Stripe**: Configurar Webhooks e IDs de produtos.
+4. **Google Ads**: Configurar IDs de conversão no tracking service.
+
+---
+**Critérios de Aceite:**
+- `npm run tenant:readiness` retorna OK.
+- Cockpit exibe métricas (mesmo que zeradas).
+- Admin consegue logar.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "stripe:trigger:checkout": "stripe trigger checkout.session.completed",
     "stripe:trigger:invoice": "stripe trigger invoice.paid",
     "stripe:trigger:cancel": "stripe trigger customer.subscription.deleted",
-    "seed:demo-tenant": "node --import tsx scripts/seed-mvp-demo-tenant.ts"
+    "seed:demo-tenant": "node --import tsx scripts/seed-mvp-demo-tenant.ts",
+    "tenant:readiness": "node --env-file=.env.local --import tsx scripts/validate-first-tenant-readiness.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1000.0",

--- a/scripts/validate-first-tenant-readiness.ts
+++ b/scripts/validate-first-tenant-readiness.ts
@@ -1,0 +1,84 @@
+import { getDb } from '../src/infra/db';
+import * as schema from '../src/drizzle/schema';
+import { eq, and } from 'drizzle-orm';
+
+async function validate() {
+  console.log('=> Starting First Tenant Readiness Validation...');
+  
+  const db = await getDb();
+  const targetTenantId = process.env.TARGET_TENANT_ID || 'demo-mvp-tenant';
+  const targetAdminEmail = process.env.TARGET_ADMIN_EMAIL || 'demo@condstore.io';
+
+  console.log(`=> Validating tenant: ${targetTenantId}`);
+
+  try {
+    // 1. Validar Tenant
+    const [tenant] = await db.select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.id, targetTenantId))
+      .limit(1);
+
+    if (!tenant) {
+      console.error(`❌ Tenant ${targetTenantId} not found in database.`);
+      process.exit(1);
+    }
+    console.log('✅ Tenant exists.');
+
+    // 2. Validar Plan Status
+    const allowedStatuses = ['active', 'trialing'];
+    if (!allowedStatuses.includes(tenant.planStatus || '')) {
+      console.error(`❌ Tenant planStatus is "${tenant.planStatus}", expected active or trialing.`);
+      process.exit(1);
+    }
+    console.log(`✅ Plan status is valid: ${tenant.planStatus}`);
+
+    // 3. Validar Usuário Admin
+    const [admin] = await db.select()
+      .from(schema.users)
+      .where(and(
+        eq(schema.users.tenantId, targetTenantId),
+        eq(schema.users.email, targetAdminEmail)
+      ))
+      .limit(1);
+
+    if (!admin) {
+      console.error(`❌ Admin user ${targetAdminEmail} not found for tenant ${targetTenantId}.`);
+      process.exit(1);
+    }
+    console.log('✅ Admin user exists.');
+
+    if (admin.role !== 'admin') {
+      console.error(`❌ User ${targetAdminEmail} has role "${admin.role}", expected "admin".`);
+      process.exit(1);
+    }
+    console.log('✅ Admin role is correct.');
+
+    // 4. Validar Configurações Mínimas (ex: WhatsApp/Twilio ou Freight)
+    const [config] = await db.select()
+      .from(schema.tenantConfigurations)
+      .where(eq(schema.tenantConfigurations.tenantId, targetTenantId))
+      .limit(1);
+    
+    if (!config) {
+      console.warn('⚠️ No specific tenant configurations found. Using system defaults.');
+    } else {
+      console.log('✅ Tenant configurations found.');
+    }
+
+    // 5. Validar dados operacionais mínimos (Conversations)
+    const conversations = await db.select({ id: schema.conversations.id })
+      .from(schema.conversations)
+      .where(eq(schema.conversations.tenantId, targetTenantId))
+      .limit(10);
+    
+    console.log(`ℹ️ Operational data: ${conversations.length} conversations found.`);
+
+    console.log('\n🚀 FIRST TENANT READINESS: OK');
+    process.exit(0);
+  } catch (error: any) {
+    console.error('❌ Readiness check failed with error:', error.message);
+    process.exit(1);
+  }
+}
+
+validate();


### PR DESCRIPTION
### Objetivo
Validar e documentar o preparo do primeiro tenant real no CONDSTORE OS.

### Escopo
- Criação de script de validação automatizada (scripts/validate-first-tenant-readiness.ts).
- Registro do comando 
pm run tenant:readiness.
- Criação do Runbook de Onboarding Técnico (docs/runbooks/first-tenant-readiness.md).

### Arquivos Alterados
- package.json: Adição do script 	enant:readiness.
- scripts/validate-first-tenant-readiness.ts: Lógica de validação de Tenant, Admin e Plano.
- docs/runbooks/first-tenant-readiness.md: Guia de onboarding.

### Resultado do Readiness Check
- **Tenant:** OK
- **Admin:** OK
- **Plano:** OK (active)
- **Dados Operacionais:** OK (1 conversation encontrada)

### Itens Fora do Escopo
- Onboarding UI, integrações reais (Twilio/Stripe), credenciais reais.

### Riscos
- Inexistentes (apenas ferramentas de validação e docs).

### Segurança
- Nenhuma secret ou credencial real foi commitada. Validado via lint:secrets-critical.