### PR TITLE
🧪 Add tests for isValidWhatsAppNumber and normalizeWhatsAppNumber in normalize.ts

### DIFF
--- a/src/lib/__tests__/normalize.test.ts
+++ b/src/lib/__tests__/normalize.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeWhatsAppNumber, isValidWhatsAppNumber } from '../normalize';
+
+describe('normalizeWhatsAppNumber', () => {
+    it('handles null, undefined, and empty string', () => {
+        expect(normalizeWhatsAppNumber(null)).toBe('');
+        expect(normalizeWhatsAppNumber(undefined)).toBe('');
+        expect(normalizeWhatsAppNumber('')).toBe('');
+    });
+
+    it('removes leading/trailing whitespace and converts to lowercase', () => {
+        expect(normalizeWhatsAppNumber(' WhatsApp:+14155238886 ')).toBe('whatsapp:+14155238886');
+        expect(normalizeWhatsAppNumber(' WHATSAPP:+14155238886 ')).toBe('whatsapp:+14155238886');
+    });
+
+    it('removes all whitespace, including spaces after colon', () => {
+        expect(normalizeWhatsAppNumber('whatsapp: +1415 523 8886')).toBe('whatsapp:+14155238886');
+        expect(normalizeWhatsAppNumber(' whatsapp: +1415 523 8886 ')).toBe('whatsapp:+14155238886');
+    });
+
+    it('removes special characters except : and +', () => {
+        expect(normalizeWhatsAppNumber('whatsapp:+1(415)-523-8886!')).toBe('whatsapp:+14155238886');
+    });
+});
+
+describe('isValidWhatsAppNumber', () => {
+    it('accepts valid canonical WhatsApp number', () => {
+        expect(isValidWhatsAppNumber('whatsapp:+14155238886')).toBe(true);
+    });
+
+    it('rejects missing + symbol', () => {
+        expect(isValidWhatsAppNumber('whatsapp:14155238886')).toBe(false);
+    });
+
+    it('rejects missing whatsapp: prefix', () => {
+        expect(isValidWhatsAppNumber('+14155238886')).toBe(false);
+        expect(isValidWhatsAppNumber(':+14155238886')).toBe(false);
+    });
+
+    it('rejects non-digit characters at the end', () => {
+        expect(isValidWhatsAppNumber('whatsapp:+14155238886a')).toBe(false);
+        expect(isValidWhatsAppNumber('whatsapp:+14155238886!')).toBe(false);
+    });
+
+    it('rejects empty string and missing numbers', () => {
+        expect(isValidWhatsAppNumber('')).toBe(false);
+        expect(isValidWhatsAppNumber('whatsapp:+')).toBe(false);
+        expect(isValidWhatsAppNumber('whatsapp:')).toBe(false);
+    });
+
+    it('rejects incorrect prefix casing if not normalized', () => {
+        expect(isValidWhatsAppNumber('WhatsApp:+14155238886')).toBe(false);
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test coverage for `isValidWhatsAppNumber` and `normalizeWhatsAppNumber` in `src/lib/normalize.ts`.

📊 **Coverage:** What scenarios are now tested:
- `normalizeWhatsAppNumber`:
  - Handles null, undefined, and empty string
  - Removes leading/trailing whitespace and converts to lowercase
  - Removes all whitespace, including spaces after colon
  - Removes special characters except : and +
- `isValidWhatsAppNumber`:
  - Accepts valid canonical WhatsApp number
  - Rejects missing + symbol
  - Rejects missing whatsapp: prefix
  - Rejects non-digit characters at the end
  - Rejects empty string and missing numbers
  - Rejects incorrect prefix casing if not normalized

✨ **Result:** The improvement in test coverage: The entire file (`src/lib/normalize.ts`) is now covered, and the logic assertions for the canonical WhatsApp inputs and normalizations are protected from regressions without affecting the codebase negatively. Tests passed correctly.

---
*PR created automatically by Jules for task [15207453236770166147](https://jules.google.com/task/15207453236770166147) started by @catcaio*