### PR TITLE
🧹 [code health] Wire follow-up scheduling action for clients

### DIFF
--- a/src/modules/clientes/actions/__tests__/schedule-followup.test.ts
+++ b/src/modules/clientes/actions/__tests__/schedule-followup.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { scheduleClientFollowUp } from '../schedule-followup';
+import { crmRepository } from '@/modules/crm/crm.repository';
+import { getTenantId } from '@/modules/audit/audit.actions';
+import { operationalAuditService } from '@/modules/audit/operational-audit.service';
+import { revalidatePath } from 'next/cache';
+
+vi.mock('@/modules/crm/crm.repository', () => ({
+    crmRepository: {
+        findActiveOpportunity: vi.fn(),
+        createOpportunity: vi.fn(),
+        createFollowUp: vi.fn(),
+    },
+}));
+
+vi.mock('@/modules/audit/audit.actions', () => ({
+    getTenantId: vi.fn().mockResolvedValue('tenant-1'),
+}));
+
+vi.mock('@/modules/audit/operational-audit.service', () => ({
+    operationalAuditService: {
+        logActivity: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
+vi.mock('next/cache', () => ({
+    revalidatePath: vi.fn(),
+}));
+
+describe('scheduleClientFollowUp', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('creates a new opportunity if none exists', async () => {
+        vi.mocked(crmRepository.findActiveOpportunity).mockResolvedValue(null);
+
+        const result = await scheduleClientFollowUp('customer-1');
+
+        expect(result.success).toBe(true);
+        expect(crmRepository.createOpportunity).toHaveBeenCalled();
+        expect(crmRepository.createFollowUp).toHaveBeenCalled();
+        expect(operationalAuditService.logActivity).toHaveBeenCalledWith(expect.objectContaining({
+            actionType: 'followup_scheduled',
+            entityId: 'customer-1'
+        }));
+        expect(revalidatePath).toHaveBeenCalled();
+    });
+
+    it('reuses existing opportunity if it exists', async () => {
+        vi.mocked(crmRepository.findActiveOpportunity).mockResolvedValue({ id: 'op-1' } as any);
+
+        const result = await scheduleClientFollowUp('customer-1');
+
+        expect(result.success).toBe(true);
+        expect(crmRepository.createOpportunity).not.toHaveBeenCalled();
+        expect(crmRepository.createFollowUp).toHaveBeenCalledWith(expect.objectContaining({
+            opportunityId: 'op-1'
+        }));
+    });
+
+    it('returns error on failure', async () => {
+        vi.mocked(crmRepository.findActiveOpportunity).mockRejectedValue(new Error('DB Error'));
+
+        const result = await scheduleClientFollowUp('customer-1');
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Erro ao agendar follow-up');
+    });
+});

--- a/src/modules/clientes/actions/schedule-followup.ts
+++ b/src/modules/clientes/actions/schedule-followup.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { randomUUID } from 'node:crypto';
+import { getTenantId } from '@/modules/audit/audit.actions';
+import { crmRepository } from '@/modules/crm/crm.repository';
+import { operationalAuditService } from '@/modules/audit/operational-audit.service';
+
+export async function scheduleClientFollowUp(customerId: string) {
+    if (!customerId) return { success: false, error: 'Customer ID is required' };
+
+    try {
+        const tenantId = await getTenantId();
+
+        // 1. Find or create an active opportunity
+        let activeOp = await crmRepository.findActiveOpportunity(tenantId, customerId);
+        let opportunityId: string;
+
+        if (!activeOp) {
+            opportunityId = randomUUID();
+            await crmRepository.createOpportunity({
+                id: opportunityId,
+                tenantId,
+                customerId,
+                title: 'Acompanhamento Manual',
+                stage: 'new_lead',
+                status: 'active',
+                lastActivityAt: new Date(),
+                createdAt: new Date(),
+            });
+        } else {
+            opportunityId = activeOp.id;
+        }
+
+        // 2. Create follow-up (48h from now)
+        const followUpId = randomUUID();
+        const scheduledAt = new Date(Date.now() + 48 * 60 * 60 * 1000);
+
+        await crmRepository.createFollowUp({
+            id: followUpId,
+            tenantId,
+            opportunityId,
+            scheduledAt,
+            description: 'Follow-up agendado manualmente via listagem de clientes',
+            status: 'pending',
+            createdAt: new Date(),
+        });
+
+        // 3. Log activity
+        await operationalAuditService.logActivity({
+            tenantId,
+            entityType: 'client',
+            entityId: customerId,
+            actionType: 'followup_scheduled',
+            afterState: { followUpId, scheduledAt, opportunityId },
+            origin: 'ui',
+            actorId: 'Sistema'
+        });
+
+        revalidatePath('/clientes');
+        revalidatePath('/cockpit/clientes');
+
+        return { success: true, scheduledAt: scheduledAt.toISOString() };
+    } catch (error) {
+        console.error('Failed to schedule follow-up:', error);
+        return { success: false, error: 'Erro ao agendar follow-up' };
+    }
+}

--- a/src/modules/clientes/clients-view.tsx
+++ b/src/modules/clientes/clients-view.tsx
@@ -17,6 +17,7 @@ import { PanelLeftClose, Kanban, List, CheckCircle2, UserPlus, FileArchive, Mess
 import { SharedKanbanBoard, KanbanColumn, KanbanCard, DropdownStatusSelector } from '@/ui/foundation';
 import { updateClientOpportunityStage } from './actions/update-stage';
 import { bulkAdvanceClientStage, bulkAssignClientOwner, bulkArchiveClients } from './actions/bulk';
+import { scheduleClientFollowUp } from './actions/schedule-followup';
 import { getOperationalHistoryAction, addOperationalNoteAction } from '@/modules/audit/audit.actions';
 import { getPendingFrankActions, approveAndExecuteFrankAction, rejectFrankAction } from '@/modules/frank';
 import { ActionPlayground } from '@/ui/frank/action-playground';
@@ -410,9 +411,14 @@ export function ClientsView({ clients }: ClientsViewProps) {
                                                                 variant="ghost" 
                                                                 size="icon" 
                                                                 className="h-6 w-6 rounded text-blue-600 hover:bg-blue-50 dark:text-blue-500 dark:hover:bg-blue-950/30" 
-                                                                onClick={(e) => { 
+                                                                onClick={async (e) => {
                                                                     e.stopPropagation(); 
-                                                                    console.warn('[TODO] Follow-up scheduling not wired yet for client:', client.id); 
+                                                                    const res = await scheduleClientFollowUp(client.id);
+                                                                    if (res.success) {
+                                                                        alert('Follow-up agendado com sucesso!');
+                                                                    } else {
+                                                                        alert(res.error || 'Erro ao agendar follow-up');
+                                                                    }
                                                                 }}
                                                             >
                                                                 <CalendarPlus className="h-3.5 w-3.5" />

--- a/src/modules/clientes/components/client-item.tsx
+++ b/src/modules/clientes/components/client-item.tsx
@@ -1,6 +1,7 @@
 import { StatusChip } from '@/ui/foundation';
 import type { ClientRecord, ClientStatus, CrmStage } from '../types';
 import { MessageCircle, CalendarPlus } from 'lucide-react';
+import { scheduleClientFollowUp } from '../actions/schedule-followup';
 
 function getStatusTone(status: ClientStatus) {
     if (status === 'vip') {
@@ -82,7 +83,19 @@ export function ClientItem({
                                 <button title="WhatsApp Ágil" className="flex h-6 w-6 items-center justify-center rounded text-emerald-600 hover:bg-emerald-50 dark:text-emerald-500 dark:hover:bg-emerald-950/30 transition-colors" onClick={() => window.open(`https://wa.me/5511999999999?text=Olar,%20${client.contact}`, '_blank')}>
                                     <MessageCircle className="h-3.5 w-3.5" />
                                 </button>
-                                <button title="Agendar Follow-up" className="flex h-6 w-6 items-center justify-center rounded text-blue-600 hover:bg-blue-50 dark:text-blue-500 dark:hover:bg-blue-950/30 transition-colors" onClick={() => console.warn('[TODO] Novo Evento not wired')}>
+                                <button
+                                    title="Agendar Follow-up"
+                                    className="flex h-6 w-6 items-center justify-center rounded text-blue-600 hover:bg-blue-50 dark:text-blue-500 dark:hover:bg-blue-950/30 transition-colors"
+                                    onClick={async (e) => {
+                                        e.stopPropagation();
+                                        const res = await scheduleClientFollowUp(client.id);
+                                        if (res.success) {
+                                            alert('Follow-up agendado com sucesso!');
+                                        } else {
+                                            alert(res.error || 'Erro ao agendar follow-up');
+                                        }
+                                    }}
+                                >
                                     <CalendarPlus className="h-3.5 w-3.5" />
                                 </button>
                             </div>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a "TODO" for follow-up scheduling in the clients view. I implemented the `scheduleClientFollowUp` server action and wired it to the UI buttons.

💡 **Why:** This improves maintainability by replacing placeholder code with a proper implementation that integrates with the existing CRM module. It ensures that clicking the "Agendar Follow-up" button actually performs a useful action (creating/finding an opportunity and scheduling a follow-up task).

✅ **Verification:** 
- Created unit tests in `src/modules/clientes/actions/__tests__/schedule-followup.test.ts` covering success and failure paths.
- Ran `npm run typecheck` to ensure no regressions or type mismatches (fixed an `ActionOrigin` type error).
- Verified that the new action revalidates the correct paths.

✨ **Result:** The follow-up scheduling feature is now functional, replacing a `console.warn` placeholder.

---
*PR created automatically by Jules for task [5582524881340677896](https://jules.google.com/task/5582524881340677896) started by @catcaio*