### PR TITLE
🔒 [security fix] Replace console.log with structured logger in MockConnector

### DIFF
--- a/src/domine/connectors/mocks/MockConnector.ts
+++ b/src/domine/connectors/mocks/MockConnector.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../../infra/logger";
 import { ConnectorAdapter, ConnectorContext } from "../ConnectorAdapter";
 import { ConnectorCapability } from "../ConnectorCapability";
 
@@ -7,7 +8,9 @@ export class MockConnector implements ConnectorAdapter {
     capabilities = [ConnectorCapability.OMS, ConnectorCapability.FISCAL];
 
     async initialize(context: ConnectorContext): Promise<void> {
-        console.log(`[MockConnector] Initialized for tenant: ${context.tenantId} with idempotency key: ${context.idempotencyKey}`);
+        logger.info("[MockConnector] Initialized", {
+            source: context.source,
+        });
     }
 
     async healthCheck(context: ConnectorContext): Promise<boolean> {
@@ -15,6 +18,9 @@ export class MockConnector implements ConnectorAdapter {
     }
 
     async sync(context: ConnectorContext): Promise<void> {
-        console.log(`[MockConnector] Sync triggered at ${context.occurredAt} from source: ${context.source}`);
+        logger.info("[MockConnector] Sync triggered", {
+            occurredAt: context.occurredAt,
+            source: context.source,
+        });
     }
 }

--- a/src/domine/connectors/mocks/__tests__/MockConnector.test.ts
+++ b/src/domine/connectors/mocks/__tests__/MockConnector.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MockConnector } from '../MockConnector';
+import { logger } from '../../../../infra/logger';
+
+vi.mock('../../../../infra/logger', () => ({
+    logger: {
+        info: vi.fn(),
+    },
+}));
+
+describe('MockConnector', () => {
+    let connector: MockConnector;
+
+    beforeEach(() => {
+        connector = new MockConnector();
+        vi.clearAllMocks();
+    });
+
+    it('should initialize and log without sensitive data', async () => {
+        const context = {
+            tenantId: 'sensitive-tenant-id',
+            idempotencyKey: 'sensitive-key',
+            source: 'test-source',
+            occurredAt: '2023-01-01T00:00:00Z',
+        };
+
+        await connector.initialize(context);
+
+        expect(logger.info).toHaveBeenCalledWith('[MockConnector] Initialized', {
+            source: 'test-source',
+        });
+
+        // Ensure tenantId and idempotencyKey are NOT logged
+        const callArgs = (logger.info as any).mock.calls[0][1];
+        expect(callArgs).not.toHaveProperty('tenantId');
+        expect(callArgs).not.toHaveProperty('idempotencyKey');
+    });
+
+    it('should sync and log without sensitive data', async () => {
+        const context = {
+            tenantId: 'sensitive-tenant-id',
+            idempotencyKey: 'sensitive-key',
+            source: 'test-source',
+            occurredAt: '2023-01-01T00:00:00Z',
+        };
+
+        await connector.sync(context);
+
+        expect(logger.info).toHaveBeenCalledWith('[MockConnector] Sync triggered', {
+            source: 'test-source',
+            occurredAt: '2023-01-01T00:00:00Z',
+        });
+
+        // Ensure tenantId and idempotencyKey are NOT logged
+        const callArgs = (logger.info as any).mock.calls[0][1];
+        expect(callArgs).not.toHaveProperty('tenantId');
+        expect(callArgs).not.toHaveProperty('idempotencyKey');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Replaced \`console.log\` with the project's structured \`logger\` in \`MockConnector.ts\`.

⚠️ **Risk:** The potential impact if left unfixed
Sensitive information like \`tenantId\` and \`idempotencyKey\` was being logged in plain text. This could lead to sensitive data exposure in production logs.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix uses the infrastructure \`logger\` which provides better control over logging. Additionally, I've modified the logging calls to explicitly exclude \`tenantId\` and \`idempotencyKey\` from the logged context, ensuring they are not persisted in logs. I also added a unit test to verify this behavior.

---
*PR created automatically by Jules for task [5710102528027522638](https://jules.google.com/task/5710102528027522638) started by @catcaio*