### PR TITLE
fix(security): block QA session bootstrap outside dev

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/internal/qa/bootstrap-session/__tests__/route.test.ts
+++ b/src/app/api/internal/qa/bootstrap-session/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression tests for QA session bootstrap lockdown.
+ *
+ * Verifies that the route returns 403 without Set-Cookie in Production
+ * and Preview environments, even when QA_BOOTSTRAP_TOKEN is valid.
+ *
+ * These tests cover the P0 security finding: an attacker holding a valid
+ * QA_BOOTSTRAP_TOKEN must NOT be able to mint an arbitrary session in Production.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ---------------------------------------------------------------------------
+// Fake test-only token — NOT a real secret, safe to commit.
+// ---------------------------------------------------------------------------
+const FAKE_QA_TOKEN = 'test-only-qa-token-000000000000000000';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBootstrapRequest(headers: Record<string, string> = {}, body: object = {}) {
+  return new NextRequest('http://localhost/api/internal/qa/bootstrap-session', {
+    method: 'POST',
+    headers: new Headers({ 'content-type': 'application/json', ...headers }),
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown — save & restore env to avoid cross-test contamination
+// ---------------------------------------------------------------------------
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    NODE_ENV: process.env.NODE_ENV,
+    APP_ENV: process.env.APP_ENV,
+    QA_BOOTSTRAP_TOKEN: process.env.QA_BOOTSTRAP_TOKEN,
+    AUTH_SECRET: process.env.AUTH_SECRET,
+  };
+
+  // Provide a valid QA token so token-auth passes — the route-level env guard
+  // must fire BEFORE token validation reaches cookie emission.
+  process.env.QA_BOOTSTRAP_TOKEN = FAKE_QA_TOKEN;
+  process.env.AUTH_SECRET = 'test-auth-secret-minimum-32-chars-!!';
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  vi.resetModules();
+});
+
+// ---------------------------------------------------------------------------
+// P0 — Production lockdown
+// ---------------------------------------------------------------------------
+
+describe('QA Bootstrap — Production lockdown (P0)', () => {
+  it('returns 403 with no Set-Cookie when VERCEL_ENV=production and token is valid', async () => {
+    process.env.VERCEL_ENV = 'production';
+    delete process.env.NODE_ENV; // remove NODE_ENV so only VERCEL_ENV signals env
+
+    // Dynamic import so env changes are visible to module initialisation.
+    const { POST } = await import('../route');
+
+    const req = makeBootstrapRequest(
+      { 'x-qa-token': FAKE_QA_TOKEN },
+      { role: 'admin', tenantId: 'evil-tenant' },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get('set-cookie')).toBeNull();
+
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+    // Must not reveal session success
+    expect(body).not.toHaveProperty('user');
+    expect(body).not.toHaveProperty('success');
+  });
+
+  it('returns 403 with no Set-Cookie when VERCEL_ENV=preview and token is valid', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    delete process.env.NODE_ENV;
+
+    const { POST } = await import('../route');
+
+    const req = makeBootstrapRequest(
+      { 'x-qa-token': FAKE_QA_TOKEN },
+      { role: 'operator', tenantId: 'evil-tenant' },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('returns 403 with no Set-Cookie when NODE_ENV=production and token is valid', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.VERCEL_ENV;
+
+    const { POST } = await import('../route');
+
+    const req = makeBootstrapRequest(
+      { 'x-qa-token': FAKE_QA_TOKEN },
+      { role: 'admin', tenantId: 'evil-tenant' },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('returns 403 without emitting cookie even when body contains arbitrary role/tenantId in preview', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    delete process.env.NODE_ENV;
+
+    const { POST } = await import('../route');
+
+    const req = makeBootstrapRequest(
+      { 'x-qa-token': FAKE_QA_TOKEN },
+      { role: 'supreme', tenantId: 'adversarial-tenant-999' },
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dev / test — should still work (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('QA Bootstrap — Dev/test passthrough', () => {
+  it('does NOT return 403 when VERCEL_ENV is unset and NODE_ENV is development', async () => {
+    // Simulate a local dev environment
+    delete process.env.VERCEL_ENV;
+    delete process.env.APP_ENV;
+    process.env.NODE_ENV = 'development';
+
+    // Mock downstream dependencies so we don't need a real DB/session signing key.
+    vi.mock('@/infra/auth/session', () => ({
+      createSessionToken: vi.fn().mockResolvedValue('fake-signed-token'),
+      COOKIE_NAME: 'condstore_session',
+    }));
+    vi.mock('@/infra/logger', () => ({
+      logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+    }));
+
+    const { POST } = await import('../route');
+
+    const req = makeBootstrapRequest(
+      { 'x-qa-token': FAKE_QA_TOKEN },
+      { role: 'admin', tenantId: 'qa-tenant' },
+    );
+
+    const res = await POST(req);
+
+    // In dev, the route should proceed past the lockdown guard.
+    // It may fail further down (e.g. session signing) but must NOT return 403.
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/internal/qa/bootstrap-session/route.ts
+++ b/src/app/api/internal/qa/bootstrap-session/route.ts
@@ -6,10 +6,24 @@ import { requireInternalAuth } from '@/infra/auth/require-internal-auth';
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/**
+ * QA Session Bootstrap — DEVELOPMENT / CI ONLY.
+ *
+ * This endpoint MUST NOT run in Production or Preview environments.
+ * `blockInProduction: true` causes requireInternalAuth to return 403 immediately
+ * when VERCEL_ENV=production|preview or NODE_ENV=production, regardless of whether
+ * QA_BOOTSTRAP_TOKEN is present and valid. No Set-Cookie is emitted in those runtimes.
+ *
+ * MANUAL_RAFA: remove QA_BOOTSTRAP_TOKEN from Vercel Production env if still present —
+ * its existence is harmless after this fix but represents unnecessary exposure.
+ */
 export async function POST(request: NextRequest) {
-    // Unified guard: blocks production, accepts QA token or internal token or admin session
+    // Security: block this route in Production and Preview unconditionally.
+    // blockInProduction delegates to isStrictRuntimeEnvironment() which covers
+    // VERCEL_ENV=production|preview, NODE_ENV=production, and APP_ENV=staging.
     const authResult = await requireInternalAuth(request, {
         purpose: ['qa_bootstrap'],
+        blockInProduction: true,
     });
 
     if (!authResult.ok) {

--- a/src/test/setup-env.ts
+++ b/src/test/setup-env.ts
@@ -1,0 +1,33 @@
+/**
+ * Vitest global setup — TEST-ONLY environment variables.
+ *
+ * ⚠️  These values are FAKE, deterministic, and MUST NEVER appear in real
+ *     production, preview, or staging environments.
+ *
+ * Purpose:
+ *  - Prevent MISSING_PII_ENCRYPTION_KEY from aborting tests that call
+ *    encryptString() / decryptString() via real code paths.
+ *  - PII_ENCRYPTION_KEY must be 64 hex chars (32 bytes).
+ *    The value below is intentionally trivial and publicly documented here.
+ *
+ * Rule: do NOT commit real secrets. This file must not reference production
+ *       or preview keys. lint:secrets-critical will flag real keys if added.
+ */
+
+// Test-only 256-bit key: 64 hex zeros — NOT a real secret.
+const TEST_ONLY_PII_ENCRYPTION_KEY = '0'.repeat(64);
+
+if (!process.env.PII_ENCRYPTION_KEY) {
+  process.env.PII_ENCRYPTION_KEY = TEST_ONLY_PII_ENCRYPTION_KEY;
+}
+
+// Ensure AUTH_SECRET is set so getAuthSecretValue() does not throw or warn.
+if (!process.env.AUTH_SECRET) {
+  process.env.AUTH_SECRET = 'test-auth-secret-minimum-32-chars-!!';
+}
+
+// Keep NODE_ENV as 'test' — isDevelopmentRuntimeStrict() checks for
+// 'development' only, but PII_ENCRYPTION_KEY is now explicitly set above
+// so the development-fallback branch is never reached in tests.
+// We do NOT override NODE_ENV here to avoid breaking other test assertions
+// that depend on NODE_ENV === 'test'.

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -34,6 +34,9 @@ export default defineConfig({
     pool: process.env.VITEST_POOL === "threads" ? "threads" : "forks",
     threads: false,
     watch: false,
+    // Injects test-only env vars (e.g. PII_ENCRYPTION_KEY) before any test module is imported.
+    // See src/test/setup-env.ts — contains ONLY fake, non-secret test values.
+    setupFiles: ["./src/test/setup-env.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary", "lcov"],


### PR DESCRIPTION
## Objetivo
Corrige P0 da auditoria final: \/api/internal/qa/bootstrap-session\ no pode emitir sesso em Production/Preview mesmo com \QA_BOOTSTRAP_TOKEN\ vlido.

## Correes
- Bloqueio explcito da rota QA bootstrap em Production/Preview.
- Garantia de 403 sem \Set-Cookie\ para token QA vlido fora de dev.
- Testes de regresso para Production/Preview.
- Ajuste do harness de testes para \PII_ENCRYPTION_KEY\ fake test-only, sem secret real.
- Correo da falha do funnel repository test (resolvida com a injeo da chave PII nos testes).

## Evidncias
- \
pm run lint:env\: PASS
- \
pm run lint:pii\: PASS
- \
pm run lint:secrets-critical\: PASS
- \
pm run routes:verify-security\: PASS
- \
pm run typecheck\: PASS
- \
pm run typecheck:mvp\: PASS
- \
pm run lint\: PASS
- \
pm run test:ci\: PASS
- \
pm run build\: PASS
- \
pm run db:verify\: PASS (implcito nos readiness checks)
- \
pm run mvp:release-candidate\: PASS

## Segurana
- Nenhum secret commitado.
- QA bootstrap bloqueado fora de dev.
- Production/Preview no emitem cookie QA.
- \QA_BOOTSTRAP_TOKEN\ em Production passa a ser incuo para essa rota.

## Pendncias
- Remover \QA_BOOTSTRAP_TOKEN\ da Vercel Production como higiene operacional, se ainda existir.