### PR TITLE
🧹 [code health] wire action buttons in logistics view

### DIFF
--- a/src/modules/logistica/logistics-view.tsx
+++ b/src/modules/logistica/logistics-view.tsx
@@ -93,8 +93,8 @@ export function LogisticsView() {
         return res;
     };
 
-    const handleBulkActionPreview = (actionType: 'update' | 'exception') => {
-        const selectedIds = Object.keys(rowSelection).filter(k => rowSelection[k]);
+    const handleBulkActionPreview = (actionType: 'update' | 'exception', explicitIds?: string[]) => {
+        const selectedIds = explicitIds || Object.keys(rowSelection).filter(k => rowSelection[k]);
         if (selectedIds.length === 0) return;
 
         const previewItems: BulkPreviewItem[] = selectedIds.map(id => {
@@ -208,12 +208,20 @@ export function LogisticsView() {
                         { 
                             id: 'actions', 
                             header: '', 
-                            cell: () => (
+                            cell: ({ row }: any) => (
                                 <div className="flex items-center gap-1 justify-end" onClick={e => e.stopPropagation()}>
-                                    <Button title="Cotar Frete" variant="ghost" size="icon" className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-blue-600 hover:bg-blue-50 dark:hover:text-blue-500 dark:hover:bg-blue-950/30 transition-colors" onClick={() => console.warn('[TODO] Cotar Frete not wired')}>
-                                        <Calculator className="h-4 w-4" />
-                                    </Button>
-                                    <Button title="Atualizar Tracking" variant="ghost" size="icon" className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-emerald-600 hover:bg-emerald-50 dark:hover:text-emerald-500 dark:hover:bg-emerald-950/30 transition-colors" onClick={() => console.warn('[TODO] Atualizar Tracking not wired')}>
+                                    <Link href={`/cockpit/freight-simulator?pedido=${row.original.order.id}`}>
+                                        <Button title="Cotar Frete" variant="ghost" size="icon" className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-blue-600 hover:bg-blue-50 dark:hover:text-blue-500 dark:hover:bg-blue-950/30 transition-colors">
+                                            <Calculator className="h-4 w-4" />
+                                        </Button>
+                                    </Link>
+                                    <Button
+                                        title="Atualizar Tracking"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-emerald-600 hover:bg-emerald-50 dark:hover:text-emerald-500 dark:hover:bg-emerald-950/30 transition-colors"
+                                        onClick={() => handleBulkActionPreview('update', [row.original.id])}
+                                    >
                                         <MapPin className="h-4 w-4" />
                                     </Button>
                                 </div>

--- a/src/modules/logistica/logistics-view.tsx
+++ b/src/modules/logistica/logistics-view.tsx
@@ -9,10 +9,26 @@ import { ActionPlayground } from '@/ui/frank/action-playground';
 import { bulkSyncLogisticsTracking, bulkReportLogisticsException } from './actions/bulk';
 import { BulkActionPreviewModal, BulkPreviewItem } from '@/ui/foundation/bulk-action-preview-modal';
 import { Truck, MapPin, AlertTriangle, Calculator, FileText, MessageSquare, Zap, RefreshCw } from 'lucide-react';
-import type { ColumnDef } from '@tanstack/react-table';
 import { useState, useEffect } from 'react';
 import { safeFetch } from '@/ui/lib/safe-fetch';
 
+type LogisticsRow = {
+    id: string;
+    simulationId?: string | null;
+    trackingCode?: string | null;
+    carrier?: string | null;
+    service?: string | null;
+    status?: string | null;
+    createdAt?: string | null;
+};
+
+function getFreightSimulatorHref(row: LogisticsRow) {
+    if (row.simulationId) {
+        return `/cockpit/freight-simulator?simulation=${encodeURIComponent(row.simulationId)}`;
+    }
+
+    return '/cockpit/freight-simulator';
+}
 
 export function LogisticsView() {
     const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
@@ -25,7 +41,7 @@ export function LogisticsView() {
     const [pendingActions, setPendingActions] = useState<any[]>([]);
     const [isLoadingActions, setIsLoadingActions] = useState(false);
 
-    const [data, setData] = useState<any[]>([]);
+    const [data, setData] = useState<LogisticsRow[]>([]);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
@@ -208,9 +224,9 @@ export function LogisticsView() {
                         { 
                             id: 'actions', 
                             header: '', 
-                            cell: ({ row }: any) => (
+                            cell: ({ row }: { row: { original: LogisticsRow } }) => (
                                 <div className="flex items-center gap-1 justify-end" onClick={e => e.stopPropagation()}>
-                                    <Link href={`/cockpit/freight-simulator?pedido=${row.original.order.id}`}>
+                                    <Link href={getFreightSimulatorHref(row.original)}>
                                         <Button title="Cotar Frete" variant="ghost" size="icon" className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-blue-600 hover:bg-blue-50 dark:hover:text-blue-500 dark:hover:bg-blue-950/30 transition-colors">
                                             <Calculator className="h-4 w-4" />
                                         </Button>
@@ -219,7 +235,7 @@ export function LogisticsView() {
                                         title="Atualizar Tracking"
                                         variant="ghost"
                                         size="icon"
-                                        className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-emerald-600 hover:bg-emerald-50 dark:hover:text-emerald-500 dark:hover:bg-emerald-950/30 transition-colors"
+                                        className="h-7 w-7 rounded text-[hsl(var(--ui-text-muted))] hover:text-emerald-600 hover:bg-emerald-50 dark:hover:text-emerald-500 dark:hover:bg-blue-950/30 transition-colors"
                                         onClick={() => handleBulkActionPreview('update', [row.original.id])}
                                     >
                                         <MapPin className="h-4 w-4" />


### PR DESCRIPTION
🎯 **What:** Wired the "Atualizar Tracking" and "Cotar Frete" buttons in `src/modules/logistica/logistics-view.tsx`.
💡 **Why:** These buttons were previously unwired and logged a TODO warning. Reusing the bulk action logic for "Atualizar Tracking" provides a consistent confirmation experience.
✅ **Verification:**
- Verified code changes in `src/modules/logistica/logistics-view.tsx`.
- Ran `npm run lint` and `npm run typecheck` (passed).
- Ran `npm run test:freight` (relevant tests passed).
- Ran `npm run guardrail:mvp-freeze` (passed).
✨ **Result:** Improved usability and code health by removing dead/unwired code and providing functional shortcuts for logistics operations.

---
*PR created automatically by Jules for task [5817991387237063504](https://jules.google.com/task/5817991387237063504) started by @catcaio*