### PR TITLE
docs: consolidate MVP final readiness and post-pilot checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ O repositório concentra uma aplicação Next.js (App Router) com:
 
 ## MVP CONDSTORE OS — Documentação oficial
 
-**Lote 1 (MVP) em produção.** Para definições completas do que é o MVP, o que faz, o que não faz e como funciona, consulte [Documentação do MVP](docs/mvp/README.md).
+**Lote 1 (MVP) consolidado para piloto real supervisionado.** O estado atual é técnico-operacional: o sistema está preparado para iniciar piloto controlado com operador humano, mas ainda não declara piloto real concluído nem mini-case de cliente. Para definições completas do que é o MVP, o que faz, o que não faz e como funciona, consulte [Documentação do MVP](docs/mvp/README.md).
 
 Links rápidos:
 - **[O que é o MVP?](docs/mvp/mvp-definition.md)** — Definição, ICP, proposta de valor
@@ -20,6 +20,14 @@ Links rápidos:
 > **Para qualquer pessoa revisando, implementando ou suportando CONDSTORE OS: Comece por [docs/mvp/README.md](docs/mvp/README.md)**
 
 Para demos/pilotos reproduzíveis, use o runbook em [`docs/demo/demo-tenant-runbook.md`](docs/demo/demo-tenant-runbook.md).
+
+## Estado de readiness
+
+- **MVP tecnicamente pronto:** main validada por gates de engenharia, com ressalva não bloqueante conhecida de Vitest threads em Windows VM; usar `npm run test:win-stable` como trilho local estável.
+- **Validação operacional controlada:** Piloto 01 teve happy path validado com evidências sanitizadas em tenant controlado; isso não equivale a piloto real de cliente concluído.
+- **Piloto real supervisionado:** próximo ciclo exige operador humano, kill switch operacional e registro de métricas reais.
+- **Pós-piloto / mini-case:** só pode ser declarado após conversas, cotações, aceites, pedidos, tempos e falhas reais serem consolidados.
+- **Rota canônica:** operadores devem usar `/cockpit`; `/dashboard` é legado e não deve aparecer em instruções operacionais ativas.
 
 ## Capacidades principais (implementadas no código)
 

--- a/docs/architecture/app-structure.md
+++ b/docs/architecture/app-structure.md
@@ -49,7 +49,7 @@ O Next.js App Router usa **route groups** `(nome)` para agrupar páginas sob lay
 | **Configurações** | `/configuracoes` | `modules/config` + `modules/auth` | Governança |
 | **Operação** | `/operacao` | `modules/cockpit` | Governança |
 | **Attribution** | `/attribution` | `modules/analytics` | — |
-| **Dashboard** | `/dashboard` | `modules/cockpit` (redirect to `/cockpit`) | — |
+| **Dashboard** | `/dashboard` | legado removido; usar `/cockpit` | — |
 | **Home** | `/home` | `modules/cockpit` (redirect to `/cockpit`) | — |
 | **Financeiro** | `/financeiro` | `modules/finops` | Legacy |
 | **Freight** | `/freight` | `modules/freight` | — |
@@ -91,6 +91,9 @@ O cockpit contém 37 subdiretórios incluindo áreas legacy:
 
 > [!NOTE]
 > Sub-pages marcadas como "Legacy" têm `navVisible: false` em `config/modules.ts`. Continuam acessíveis via URL direta mas não aparecem na navegação principal.
+
+> [!IMPORTANT]
+> `/cockpit` é a rota canônica do operador. `/dashboard` não deve ser usado em documentação operacional ativa.
 
 ---
 

--- a/docs/cockpit-route-audit.md
+++ b/docs/cockpit-route-audit.md
@@ -6,8 +6,8 @@
 
 | Rota Atual | Tipo | Módulo | Destino |
 |---|---|---|---|
-| `/cockpit` | page | cockpit root | `/dashboard` |
-| `/cockpit/overview` | page | dashboard | `/dashboard` |
+| `/cockpit` | page | cockpit root | canônico |
+| `/cockpit/overview` | page | legacy overview | não orientar operador; usar `/cockpit` |
 | `/cockpit/status` | page | sistema | `/sistema/health` |
 | `/cockpit/status/audit` | page | sistema | `/sistema/logs` |
 | `/cockpit/security` | page | sistema | `/sistema/security` |
@@ -16,7 +16,7 @@
 | `/cockpit/acquisition` | page | vendas | `/vendas/cotacao` |
 | `/cockpit/acquisition/activation` | page | vendas | `/vendas/cotacao/activation` (futuro) |
 | `/cockpit/acquisition/drilldown` | page | vendas | `/vendas/cotacao/drilldown` (futuro) |
-| `/cockpit/metrics` | page | dashboard | `/dashboard` (merge) |
+| `/cockpit/metrics` | page | métricas | manter como subrota de `/cockpit` |
 | `/cockpit/actions` | page | operação | `/operacao/actions` (futuro) |
 | `/cockpit/audit` | page | sistema | `/sistema/logs` (merge) |
 | `/cockpit/carrier-tables` | page | logística | `/logistica/carrier-tables` (futuro) |
@@ -68,7 +68,7 @@ As rotas a mover nesta entrega:
 | `/cockpit/freight-simulator` | `/logistica/simulador` | Sim — copiar page+client |
 | `/cockpit/shipments` | `/logistica/envios` | ✅ já existe |
 | `/cockpit/freight-insights` | `/logistica/insights` | ✅ já existe |
-| `/cockpit` (root) | `/dashboard` | Sim — criar stub/redirect |
+| `/cockpit` (root) | canônico | Não migrar para `/dashboard`; manter como rota operacional ativa |
 | `/inbox` | `/operacao/inbox` | Sim — copiar page+client |
 | `/cockpit/domine/dlq` | `/sistema/dlq` | Sim — copiar page+client |
 | `/cockpit/security` | `/sistema/security` | Sim — copiar page+client |

--- a/docs/pilot-ready-internal-checklist.md
+++ b/docs/pilot-ready-internal-checklist.md
@@ -57,9 +57,10 @@ Este documento consolida a avaliação final para a transição do sistema para 
 
 ## Decisão Final
 
-**Status:** [X] GO  /  [ ] NO-GO  /  [ ] GO COM RESSALVAS
+**Status:** [ ] GO  /  [ ] NO-GO  /  [X] GO COM RESSALVAS
 
 **Ressalvas (se houver):**
-- _Nenhuma ressalva impeditiva identificada até o momento._
+- Vitest em modo `threads` pode apresentar instabilidade não bloqueante em Windows VM; usar `npm run test:win-stable` como trilho local estável.
+- Este checklist declara readiness para iniciar piloto real supervisionado, não piloto real concluído.
 
-**Assinatura:** Jules (Automated Validation) **Data:** 2026-05-09
+**Assinatura:** Codex Release Audit **Data:** 2026-05-17

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -38,7 +38,13 @@ Objetivo: sair da demo para piloto real com um processo simples, visível e repe
    Usar a partir do início do piloto para registrar baseline, scorecard e revisão semanal.
 
 7. `pilot-01-operational-checklist.md`
-   Executar o checklist operacional supervisionado durante a operação do primeiro piloto para garantir o fluxo happy-path e coletar evidências.
+   Usar como evidência da validação operacional controlada e como trilho de execução do primeiro piloto real supervisionado.
+
+8. `mvp-final-readiness-report.md`
+   Ler antes de iniciar o piloto real para confirmar escopo, ressalvas, gates e critérios de conclusão.
+
+9. `pilot-01-post-pilot-checklist.md`
+   Preencher somente depois do piloto real com métricas reais, evidências sanitizadas e decisão de expansão/repetição/pausa/correção.
 
 ---
 
@@ -47,6 +53,7 @@ Objetivo: sair da demo para piloto real com um processo simples, visível e repe
 - Não pular etapa do funil.
 - Não marcar `Qualificado` sem confirmar problema real de cotação e operação por WhatsApp.
 - Não marcar `Piloto fechado` sem responsável do cliente, escopo, prazo e data de onboarding.
+- Não declarar `piloto validado` ou `mini-case` sem checklist pós-piloto preenchido com dados reais.
 - Atualizar `pilot-status.md` no mesmo dia da interação.
 - Se um lead ficar 7 dias sem próximo passo definido, tratar como lead parado e revisar.
 

--- a/docs/pilots/mvp-final-readiness-report.md
+++ b/docs/pilots/mvp-final-readiness-report.md
@@ -1,0 +1,117 @@
+# MVP Final Readiness Report — CONDSTORE OS
+
+**Data da auditoria:** 2026-05-17  
+**Branch:** `chore/p2-mvp-final-readiness`  
+**Main auditada:** `f4749ecdfa7233ec0e8f3255ec883d4ce0855af1`  
+**Status final:** `GO COM RESSALVA` para abrir PR de consolidação documental; piloto real ainda depende de execução supervisionada e checklist pós-piloto.
+
+## Estado final do MVP
+
+O MVP está tecnicamente consolidado para iniciar um piloto real supervisionado. O estado atual não declara piloto real concluído, resultado comercial validado nem mini-case pós-piloto.
+
+Classificação operacional:
+
+| Camada | Status | Evidência |
+|---|---|---|
+| MVP tecnicamente pronto | OK com ressalva | Tarefa 1/5 validou main com ressalva não bloqueante de Vitest threads no Windows VM; trilho local estável: `npm run test:win-stable`. |
+| Validação operacional controlada | OK | Tarefa 2/5 registrou evidências reais e sanitizadas em `docs/pilots/pilot-01-operational-checklist.md` para tenant controlado. |
+| Piloto real supervisionado | Próximo ciclo | Requer operador humano, kill switch, métricas reais e checklist pós-piloto. |
+| Mini-case pós-piloto | Não iniciado | Só pode ser produzido após `docs/pilots/pilot-01-post-pilot-checklist.md` completo com dados reais. |
+
+## Validações das tarefas 1/5 a 4/5
+
+- **Tarefa 1/5:** main tecnicamente pronta, com ressalva não bloqueante de instabilidade de Vitest threads em Windows VM.
+- **Tarefa 2/5:** Piloto 01 validado em modo operacional controlado, com evidências sanitizadas no checklist operacional.
+- **Tarefa 3/5:** PR #328 mergeada — cockpit canônico em `/cockpit`, remoção do `/dashboard` legado como orientação ativa e fallback honesto.
+- **Tarefa 4/5:** PR #329 mergeada — governança de repo, CODEOWNERS, PR template e workflows de agentes.
+
+## PRs relevantes
+
+- PR #328: https://github.com/catcaio/projeto-condstore/pull/328
+- PR #329: https://github.com/catcaio/projeto-condstore/pull/329
+
+## Gates executados nesta consolidação
+
+| Gate | Resultado | Observação |
+|---|---|---|
+| `npm run lint` | PASS local | Exit code 0. |
+| `npm run typecheck` | PASS local | Exit code 0. |
+| `npm run routes:verify-security` | PASS local | Exit code 0; 195 rotas protegidas com guardrails e sem extração insegura de tenant/user via request. |
+| `npm run db:verify` | PASS local com ressalva | Exit code 0; rodou em modo offline porque `DATABASE_URL` não estava presente no shell local; schema alinhado com migrations commitadas. |
+| `npm run test:win-stable` | PASS local | Exit code 0; trilho estável em Windows VM. |
+| `npm run pilot:readiness` | PASS local com ressalva | Exit code 0; emitiu avisos `MANUAL_RAFA` para envs de Google/SMTP/Stripe e não prova piloto real concluído. |
+| `npm run mvp:release-candidate` | PASS local com ressalva | Exit code 0; emitiu avisos `MANUAL_RAFA` e assumiu login/API sem servidor local ativo; é gate técnico, não prova resultado comercial. |
+| `npm run build` | PASS local com warning | Exit code 0; build gerou warning de `middleware` deprecated/proxy e warning Turbopack NFT em rota interna Qdrant, sem falha de build. |
+| `npm run guardrail:mvp-freeze` | PASS local | Exit code 0; nenhuma superfície hard-frozen alterada. |
+| `npm run scope:pr-tests` | PASS local | Exit code 0; escopo docs-only e comando mínimo sugerido: `npm run guardrail:mvp-freeze`. |
+
+## Auditoria de mocks, fallbacks e valores fictícios
+
+Busca local executada por `mock-data`, `fallback`, `demo`, `N/A`, `126`, `248`, `412` e `17`.
+
+Classificação:
+
+| Classe | Resultado |
+|---|---|
+| Teste/demo permitido | Diretórios `docs/demo/**`, scripts de seed demo e testes de cockpit usam dados fictícios explicitamente para demo/teste. |
+| Fallback explícito permitido | Cockpit usa fallback diagnóstico com `source=fallback`, `fallbackReason` e valores `N/A`, sem KPIs fictícios. Rate limiter, Redis e PII têm fallbacks delimitados por runtime/dev ou modo degradado. |
+| Produção suspeita | `src/app/api/cockpit/conversations/[id]/route.ts` usa `N/A`/`<N/A>` para campos ainda não rastreados (`source`, `cidade`, `uf`). Não há evidência de KPI fictício ou decisão automática baseada nesses valores; manter no backlog de refinamento de dados, sem blocker desta PR. |
+| Blocker real | Nenhum mock/fallback silencioso bloqueante identificado nesta auditoria documental. |
+
+## Cockpit e rotas
+
+- `/cockpit` é a rota canônica do operador.
+- `/dashboard` não deve ser documentado como rota operacional ativa.
+- O fallback do cockpit é diagnóstico honesto, com `source=fallback` e `fallbackReason`; não deve ser interpretado como dado real.
+- Valores antigos `126`, `248`, `412` aparecem como asserções negativas/testes ou substrings incidentais, não como KPI produtivo de cockpit.
+
+## Riscos remanescentes
+
+- Piloto real ainda não mediu volume real de conversas, cotações, aceites, pedidos, tempos e falhas.
+- Integrações externas continuam dependentes de ambiente configurado e monitoramento ativo.
+- Mini-case comercial não pode ser publicado sem evidências pós-piloto e aprovação humana.
+- Campos operacionais não rastreados ainda podem aparecer como `N/A`; devem ser tratados como lacuna de qualidade de dados, não como prova de operação.
+
+## Ressalvas não bloqueantes
+
+- Vitest em modo `threads` pode ser instável em Windows VM; usar `npm run test:win-stable` como gate local.
+- Readiness scripts são evidência técnica, não substituem operação real supervisionada.
+- Fallback diagnóstico do cockpit é aceitável porque é explícito e não apresenta dados reais falsos.
+
+## Critérios para iniciar piloto real
+
+- Branch de readiness mergeada na `main`.
+- Gates obrigatórios desta PR aprovados ou ressalva formalmente aceita.
+- Operador humano definido e treinado no fluxo `/cockpit`.
+- Kill switch documentado e acionável.
+- Ambiente real com Twilio, banco, Redis, frete e autenticação configurados.
+- Plano de coleta de métricas reais aprovado por Rafael/operador.
+
+## Critérios para declarar piloto real concluído
+
+- `docs/pilots/pilot-01-post-pilot-checklist.md` preenchido com dados reais.
+- Métricas mínimas consolidadas: conversas, cotações, aceites, pedidos, tempos médios e falhas.
+- Screenshots/logs sanitizados anexados.
+- Falhas operacionais, UX e dados classificadas.
+- Decisão final registrada: expandir, repetir piloto, pausar ou corrigir.
+- Rafael e operador humano aprovam interpretação das evidências.
+
+## Checklist pós-piloto
+
+Usar `docs/pilots/pilot-01-post-pilot-checklist.md` como trilho obrigatório para:
+
+- volume real de conversas;
+- volume real de cotações e aceites;
+- pedidos criados;
+- tempos médios;
+- falhas;
+- evidências sanitizadas;
+- mini-case before/after;
+- decisão final.
+
+## Próximas decisões humanas
+
+- Rafael confirma se a ressalva de Windows/Vitest threads continua não bloqueante para merge.
+- Operador humano confirma disponibilidade para executar o piloto real.
+- Rafael/operador definem limite de volume inicial, critérios de pausa e janela de revisão.
+- Rafael aprova qualquer uso comercial de mini-case após sanitização e autorização.

--- a/docs/pilots/pilot-01-operational-checklist.md
+++ b/docs/pilots/pilot-01-operational-checklist.md
@@ -1,6 +1,8 @@
-# Checklist Operacional — Piloto 01 (Supervisionado)
+# Checklist Operacional — Piloto 01 (Validação Controlada Supervisionada)
 
-Este checklist detalha os passos operacionais necessários para a execução do Piloto 01 do **CONDSTORE OS**. O foco é a validação do fluxo "Happy Path" com supervisão humana direta (Human-in-the-Loop), garantindo que cada transição de estado seja validada antes de avançar.
+Este checklist detalha a validação operacional controlada do Piloto 01 do **CONDSTORE OS**. O foco é provar o fluxo "Happy Path" com supervisão humana direta (Human-in-the-Loop), garantindo que cada transição de estado seja validada antes de avançar.
+
+**Status:** validação operacional controlada concluída em tenant controlado. Este documento **não** declara piloto real de cliente concluído nem mini-case pós-piloto.
 
 ---
 
@@ -75,7 +77,7 @@ Este checklist detalha os passos operacionais necessários para a execução do 
 
 ---
 
-## EVIDÊNCIAS ESPERADAS (Placeholder para Execução)
+## Evidências capturadas
 
 *Nota: Evidências capturadas da base operacional e logs estruturados em 17/05/2026 para o tenant demo-mvp-tenant.*
 
@@ -91,7 +93,9 @@ Este checklist detalha os passos operacionais necessários para a execução do 
 
 ---
 
-## MINI-CASE: Template Before/After
+## Mini-case preliminar: before/after de validação controlada
+
+Este bloco é um modelo preliminar baseado em validação controlada. O mini-case público ou comercial só pode ser produzido após piloto real supervisionado com métricas reais do cliente.
 
 **Empresa:** Tenant Demo MVP Condstore
 **Data:** 17/05/2026

--- a/docs/pilots/pilot-01-post-pilot-checklist.md
+++ b/docs/pilots/pilot-01-post-pilot-checklist.md
@@ -1,0 +1,58 @@
+# Checklist Pós-Piloto 01 — CONDSTORE OS
+
+Preencher somente após o piloto real supervisionado. Não usar dados de demo, seed ou validação controlada como métrica de cliente.
+
+## Identificação
+
+- [ ] Cliente:
+- [ ] Tenant:
+- [ ] Período do piloto:
+- [ ] Operador responsável:
+- [ ] Rafael/owner técnico presente na revisão:
+
+## Métricas reais
+
+- [ ] Quantidade real de conversas processadas:
+- [ ] Quantidade real de cotações geradas:
+- [ ] Quantidade real de cotações aceitas:
+- [ ] Quantidade real de pedidos criados:
+- [ ] Tempo médio de resposta:
+- [ ] Tempo médio de cotação:
+- [ ] Taxa de conversão cotação -> aceite:
+- [ ] Taxa de conversão aceite -> pedido:
+
+## Falhas e evidências
+
+- [ ] Falhas operacionais registradas:
+- [ ] Falhas de UX registradas:
+- [ ] Falhas de dados/métricas registradas:
+- [ ] Incidentes de integração ou webhook:
+- [ ] Acionamentos de kill switch:
+- [ ] Screenshots sanitizados anexados:
+- [ ] Logs sanitizados anexados:
+- [ ] PII removida ou mascarada em todos os anexos:
+
+## Mini-case before/after
+
+- [ ] Dor operacional antes do piloto:
+- [ ] Fluxo executado durante o piloto:
+- [ ] Evidência de ganho real:
+- [ ] Limitação observada:
+- [ ] Citação autorizada do operador/cliente:
+- [ ] Materiais aprovados para uso comercial:
+
+## Decisão final
+
+Marcar uma decisão única:
+
+- [ ] Expandir piloto
+- [ ] Repetir piloto com ajustes
+- [ ] Pausar
+- [ ] Corrigir antes de novo ciclo
+
+## Aprovações humanas
+
+- [ ] Rafael aprovou decisão final.
+- [ ] Operador humano aprovou evidências e interpretação.
+- [ ] Próximo backlog pós-piloto foi priorizado.
+- [ ] Itens de segurança/PII foram revisados antes de qualquer publicação.

--- a/docs/pilots/risk-and-kill-switch-plan.md
+++ b/docs/pilots/risk-and-kill-switch-plan.md
@@ -54,6 +54,7 @@ Após o acionamento do Kill Switch:
 5. Registrar incidente no `Audit Log`.
 
 ---
-**Status**: READY_FOR_PILOT_06
-**Versão**: 1.0.0
-**Data**: 2026-05-10
+**Status**: READY_FOR_PILOT_REAL_SUPERVISIONADO
+**Escopo do status**: plano pronto para iniciar piloto real controlado. Não declara piloto real concluído.
+**Versão**: 1.1.0
+**Data**: 2026-05-17

--- a/docs/routes-map.md
+++ b/docs/routes-map.md
@@ -36,11 +36,11 @@ This document defines the canonical route architecture for the Condstore OS publ
 | `/settings/security` | Key management, IP whitelisting, Rate Limits | Super Admin | `securityService` |
 | `/settings/knowledge` | RAG & Vector DB collections management | Super Admin | `knowledgeService` |
 
-## 🔵 Tenant Dashboard (Future)
+## 🔵 Dashboard legado
 
 | Route | Objective | Auth | Data Source |
 |---|---|---|---|
-| `/dashboard` | Tenant-specific operational overview (Placeholder) | Tenant User | TBD |
+| `/dashboard` | Legado removido; não usar em instruções operacionais | N/A | N/A |
 
 ---
 *Note: Any routes not listed above within `/cockpit/` are considered orphans and will be redirected to their canonical counterparts.*

--- a/docs/routes-registry.md
+++ b/docs/routes-registry.md
@@ -296,7 +296,7 @@
 | /cotacao | TBA | public | none | PUBLIC | live | Auto-detected |
 | /cotacao/result | TBA | public | none | PUBLIC | live | Auto-detected |
 | /crm-whatsapp | CRM e WhatsApp | public | none | PUBLIC | live | Landing page de CRM e WhatsApp |
-| /dashboard | GET | internal | required | cockpit | live | Alias legado redirecionado para o cockpit canônico |
+| /dashboard | GET | internal | required | cockpit | deprecated | Legado removido das instruções operacionais; usar /cockpit |
 | /docs | TBA | public | none | PUBLIC | live | Auto-detected |
 | /evolution | TBA | public | none | PUBLIC | live | Auto-detected |
 | /evolution/[id] | TBA | public | none | PUBLIC | live | Auto-detected |

--- a/docs/runbooks/mvp-release-candidate.md
+++ b/docs/runbooks/mvp-release-candidate.md
@@ -4,7 +4,7 @@ Este documento descreve o processo de validação final para o lançamento do MV
 
 ## 1. O que é o Release Candidate Gate?
 
-É o portal de validação operacional agregada. Ele garante que Frete, WhatsApp, Stripe, Rastreamento, Interface Cockpit, E-mail e Autenticação estão operacionais, respondem nos contratos esperados e não acionam erros fatais silenciosos no runtime da Vercel.
+É o portal de validação operacional agregada. Ele verifica que Frete, WhatsApp, Stripe, Rastreamento, Interface Cockpit, E-mail e Autenticação respondem nos contratos esperados e não acionam erros fatais silenciosos no runtime da Vercel.
 
 O script principal reside em `scripts/validate-mvp-release-candidate.ts`.
 
@@ -33,7 +33,7 @@ O gate executa sequencialmente:
 
 ## 4. Critérios de Aceite
 
-O sistema é considerado `MVP_RELEASE_CANDIDATE_OK` somente se:
+O sistema é considerado tecnicamente `MVP_RELEASE_CANDIDATE_OK` somente se:
 - Todos os scripts de `readiness` passarem (exit code 0).
 - A API de login responder JSON estruturado (mesmo que erro 401/500 JSON).
 - Não houver crash de runtime (HTML 500) em rotas críticas.
@@ -47,4 +47,4 @@ Se a pipeline acusar falha na subida para PR ou na checagem local:
 2.  Não tente contornar erros de servidor mudando a stack; trate os erros e garanta retornos serializáveis em JSON para consumo adequado na UI.
 3.  Verifique se os itens manuais (SMTP, OAuth, Stripe, Twilio) foram configurados diretamente nas variáveis de ambiente da Vercel.
 
-O sistema só pode ser entregue ao Operador de fato se todas as frentes validarem com sucesso.
+O sistema só pode iniciar piloto real supervisionado se todas as frentes validarem com sucesso e se o operador humano confirmar o plano de execução, kill switch e coleta de métricas. Este gate não declara piloto real concluído nem resultado comercial validado.

--- a/docs/runbooks/pilot-launch-readiness.md
+++ b/docs/runbooks/pilot-launch-readiness.md
@@ -17,4 +17,4 @@ A execução do comando acima validará:
 - [ ] Tracking Readiness
 - [ ] Cockpit Smoke Test
 
-Se todas as etapas retornarem OK, a infraestrutura lógica do MVP está pronta.
+Se todas as etapas retornarem OK, a infraestrutura lógica do MVP está pronta para iniciar piloto real supervisionado. O comando não comprova piloto real executado, resultado comercial, mini-case ou ausência de falhas operacionais em produção.


### PR DESCRIPTION
## Objetivo
Consolidar o estado final do MVP Pilot-Ready após as tarefas 1/5 a 4/5, separando readiness técnica, validação operacional controlada, piloto real supervisionado e pós-piloto/mini-case.

## Escopo real
- Cria `docs/pilots/mvp-final-readiness-report.md` com SHA da main auditada, PRs #328/#329, gates, riscos, ressalvas e critérios de piloto.
- Cria `docs/pilots/pilot-01-post-pilot-checklist.md` para métricas reais pós-piloto.
- Atualiza README, docs de pilotos, runbooks de readiness e docs de rotas para remover overclaim.
- Consolida `/cockpit` como rota canônica e marca `/dashboard` como legado/deprecated nas instruções operacionais.

## Fora de escopo
- Nenhuma feature nova.
- Nenhuma alteração de runtime.
- Nenhuma alteração de banco/migrations.
- Nenhuma ativação de Frank autônomo.
- Nenhuma evidência fictícia criada.

## Arquivos alterados
- `README.md`
- `docs/pilots/mvp-final-readiness-report.md`
- `docs/pilots/pilot-01-post-pilot-checklist.md`
- `docs/pilots/pilot-01-operational-checklist.md`
- `docs/pilots/risk-and-kill-switch-plan.md`
- `docs/pilots/README.md`
- `docs/pilot-ready-internal-checklist.md`
- `docs/runbooks/mvp-release-candidate.md`
- `docs/runbooks/pilot-launch-readiness.md`
- `docs/architecture/app-structure.md`
- `docs/cockpit-route-audit.md`
- `docs/routes-map.md`
- `docs/routes-registry.md`

## Evidência dos gates
- `npm run guardrail:mvp-freeze` — PASS local, exit 0; nenhuma superfície hard-frozen alterada.
- `npm run scope:pr-tests` — PASS local, exit 0; escopo docs-only, mínimo sugerido `npm run guardrail:mvp-freeze`.
- `npm run lint` — PASS local, exit 0.
- `npm run typecheck` — PASS local, exit 0.
- `npm run routes:verify-security` — PASS local, exit 0; 195 rotas protegidas com guardrails, sem extração insegura de tenant/user via request.
- `npm run db:verify` — PASS local com ressalva, exit 0; modo offline por ausência de `DATABASE_URL` no shell local, schema alinhado com migrations.
- `npm run test:win-stable` — PASS local, exit 0.
- `npm run pilot:readiness` — PASS local com ressalva, exit 0; avisos `MANUAL_RAFA` para envs Google/SMTP/Stripe; não prova piloto real concluído.
- `npm run mvp:release-candidate` — PASS local com ressalva, exit 0; avisos `MANUAL_RAFA` e login/API assumido sem servidor local ativo; gate técnico, não resultado comercial.
- `npm run build` — PASS local com warnings, exit 0; warning de `middleware` deprecated/proxy e warning Turbopack NFT em rota interna Qdrant, sem falha de build.

## Auditoria mocks/fallbacks
Busca local feita por `mock-data`, `fallback`, `demo`, `N/A`, `126`, `248`, `412`, `17`.

Classificação:
- Teste/demo permitido: `docs/demo/**`, seeds demo e testes usam dados fictícios explicitamente.
- Fallback explícito permitido: cockpit usa `source=fallback`, `fallbackReason` e `N/A` sem KPIs fictícios; fallbacks Redis/PII/rate limiter são delimitados por runtime/dev/degraded mode.
- Produção suspeita não bloqueante: `src/app/api/cockpit/conversations/[id]/route.ts` usa `N/A`/`<N/A>` para campos não rastreados (`source`, `cidade`, `uf`); sem evidência de KPI fictício ou decisão automática.
- Blocker real: nenhum mock/fallback silencioso bloqueante encontrado.

## Riscos remanescentes
- Piloto real ainda não mediu volume real de conversas, cotações, aceites, pedidos, tempos e falhas.
- Mini-case comercial depende do checklist pós-piloto com dados reais e aprovação humana.
- Readiness scripts passam localmente, mas ainda emitem avisos `MANUAL_RAFA`; ambiente real precisa ser confirmado antes do piloto.
- Build tem warnings não bloqueantes já registrados.

## Rollback
Reverter este commit remove apenas documentação e checklist. Não há impacto em runtime, banco ou migrações.

## Confirmação de ausência de overclaim
- Documentos agora distinguem MVP tecnicamente pronto, validação operacional controlada, piloto real supervisionado e mini-case pós-piloto.
- `pilot-01-operational-checklist.md` não declara piloto real de cliente concluído.
- Fallback do cockpit é documentado como diagnóstico, não dado real.
- `/dashboard` não é orientado como rota operacional ativa; `/cockpit` é canônico.

## Status final
GO COM RESSALVA — MVP final readiness consolidada para PR, com ressalvas de env local `MANUAL_RAFA`, `db:verify` offline, warning de build e necessidade de checklist pós-piloto para declarar resultado real.
